### PR TITLE
Syntax shortcuts (MS and extension)

### DIFF
--- a/samples/USCoreMedicationRequest.fsh
+++ b/samples/USCoreMedicationRequest.fsh
@@ -8,30 +8,28 @@ Description:    """
     Defines constraints and extensions on the MedicationRequest resource 
     for the minimal set of data to query and retrieve prescription information."""
 // publisher, contact, jurisdiction, other metadata here
-* status MS
-* intent MS
-* reported[x] MS
+// NOTE: MS can also be done in multiple lines:
+// * status MS
+// * intent MS
+// ...
+* status, intent, reported[x], medication[x], subject, encounter, authoredOn,
+  requester, dosageInstruction, dosageInstruction.text MS
 * reported[x] only boolean or Reference(USCorePatient 
     | USCorePractitioner 
     | PractitionerRole 
     | USCoreOrganization 
     | RelatedPerson)
-* medication[x] MS
 * medication[x] only CodeableConcept or Reference(USCoreMedication)
 * medicationCodeableConcept from USCoreMedicationCodes (extensible)
-* subject MS
 * subject only Reference(USCorePatient)
-* encounter MS
-* authoredOn 1..1 MS
-* requester 1..1 MS
+* authoredOn 1..1
+* requester 1..1
 * requester only Reference(USCorePractitioner
     | PractitionerRole
     | USCoreOrganization
     | USCorePatient
     | USCoreImplantableDevice
     | RelatedPerson)
-* dosageInstruction MS
-* dosageInstruction.text MS
 
 ValueSet:       USCoreMedicationCodes
 Id:             us-core-medication-codes

--- a/samples/USCorePatient.fsh
+++ b/samples/USCorePatient.fsh
@@ -21,36 +21,32 @@ Description:    """
 * ^contact.telecom.value = "http://www.healthit.gov"
 * ^jurisdiction.coding = COUNTRY#US "United States of America"
 * ^fhirVersion = "4.0.0"
+// NOTE: MS can also be done in multiple lines:
+// * identifier MS
+// * identifier.system MS
+// ...
+* identifier, identifier.system, identifier.value, name, name.family, name.given
+  telecom, telecom.system, telecom.value, telecom.use, gender, birthDate, address,
+  address.line, address.city, address.state, address.postalCode, communication,
+  communication.language MS
 * extension contains 
     USCoreRaceExtension 0..1 MS and 
     USCoreEthnicityExtension 0..1 MS and 
     USCoreBirthsexExtension 0..1 MS
-* identifier 1..* MS 
-* identifier.system 1..1 MS
-* identifier.value 1..1 MS
+* identifier 1..*
+* identifier.system 1..1
+* identifier.value 1..1
 * identifier.value ^short = "The value that is unique within the system"
-* name 1..* MS
+* name 1..*
 * name obeys us-core-8
-* name.family MS
-* name.given MS
-* telecom MS
-* telecom.system 1..1 MS
+* telecom.system 1..1
 * telecom.system from http://hl7.org/fhir/ValueSet/contact-point-system (required)
-* telecom.value 1..1 MS
-* telecom.use MS
+* telecom.value 1..1
 * telecom.use from http://hl7.org/fhir/ValueSet/contact-point-use (required)
-* gender 1..1 MS
+* gender 1..1
 * gender from http://hl7.org/fhir/ValueSet/administrative-gender // (required)
-* birthDate MS
-* address MS
-* address.line MS
-* address.city MS
-* address.state MS 
 * address.state from USPSTwoLetterAlphabeticCodes (extensible)
-* address.postalCode MS
 * address.postalCode ^short = "US Zip Codes"
-* communication MS
-* communication.language MS
 * communication.language from LanguageCodesWithLanguageAndOptionallyARegionModifier (extensible)
 
 Extension:      USCoreRaceExtension
@@ -67,17 +63,19 @@ Description:    """
     or Other Pacific Islander - White."""
 // publisher, contact, jurisdiction, other metadata here
 * extension contains ombCategory 0..5 MS and detailed 0..* and text 1..1 MS
-* extension[ombCategory] ^short = """
+// * extension[ombCategory] ^short = ...
+// NOTE: The line below is a shortcut syntax for the explicit syntax of the line above
+* ombCategory ^short = """
     American Indian or Alaska Native|Asian|Black or 
     African American|Native Hawaiian or Other Pacific Islander|White"""
 // * extension[ombCategory].url = "ombCategory" - Can be inferred from slice names above
-* extension[ombCategory].value[x] only Coding
-* extension[ombCategory].valueCoding from OmbRaceCategories // (required)
-* extension[detailed] ^short = "Extended race codes"
-* extension[detailed].value[x] only Coding
-* extension[detailed].valueCoding from DetailedRace // (required)
-* extension[text] ^short = "Race Text"
-* extension[text].value[x] only string
+* ombCategory.value[x] only Coding
+* ombCategory.valueCoding from OmbRaceCategories // (required)
+* detailed ^short = "Extended race codes"
+* detailed.value[x] only Coding
+* detailed.valueCoding from DetailedRace // (required)
+* text ^short = "Race Text"
+* text.value[x] only string
 
 Extension:      USCoreEthnicityExtension
 Id:             us-core-ethnicity
@@ -92,14 +90,14 @@ Description:    """
     to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino."""
 // publisher, contact, jurisdiction, other metadata here
 * extension contains ombCategory 0..1 MS and detailed 0..* and text 1..1 MS
-* extension[ombCategory] ^short = "Hispanic or Latino|Not Hispanic or Latino"
-* extension[ombCategory].value[x] only Coding
-* extension[ombCategory].valueCoding from OmbEthnicityCategories (required)
-* extension[detailed] ^short = "Extended ethnicity codes"
-* extension[detailed].value[x] only Coding
-* extension[detailed].valueCoding from DetailedEthnicity (required)
-* extension[text] ^short = "ethnicity Text"
-* extension[text].value[x] only string
+* ombCategory ^short = "Hispanic or Latino|Not Hispanic or Latino"
+* ombCategory.value[x] only Coding
+* ombCategory.valueCoding from OmbEthnicityCategories (required)
+* detailed ^short = "Extended ethnicity codes"
+* detailed.value[x] only Coding
+* detailed.valueCoding from DetailedEthnicity (required)
+* text ^short = "ethnicity Text"
+* text.value[x] only string
 
 Extension:      USCoreBirthSexExtension 
 Id:             us-core-birthsex

--- a/samples/USCorePatientExample.fsh
+++ b/samples/USCorePatientExample.fsh
@@ -5,17 +5,19 @@ Instance:       PatientExample
 Title:          "Patient Example"
 InstanceOf:     USCorePatient
 * id = "example"
-* extension[us-core-race].extension[ombCategory][0].valueCoding = RACE#2160-3 "White"
-* extension[us-core-race].extension[ombCategory][1].valueCoding = RACE#1002-5 "American Indian or Alaska Native"
-* extension[us-core-race].extension[ombCategory][2].valueCoding = RACE#2028-9 "Asian"
-* extension[us-core-race].extension[detailed][0].valueCoding = RACE#1586-7 "Shoshone"
-* extension[us-core-race].extension[detailed][1].valueCoding = RACE#2036-2 "Filipino"
-* extension[us-core-race].extension[text].valueString = "Mixed"
-* extension[us-core-ethnicity].extension[ombCategory].valueCoding = RACE#2135-2 "Hispanic or Latino"
-* extension[us-core-ethnicity].extension[detailed][0].valueCoding = RACE#2184-0 "Dominican"
-* extension[us-core-ethnicity].extension[detailed][1].valueCoding = RACE#2148-5 "Mexican"
-* extension[us-core-ethnicity].extension[text].valueString = "Hispanic or Latino"
-* extension[us-core-birthsex].valueCode = #F
+// * extension[us-core-race].extension[ombCategory][0].valueCoding = RACE#2160-3 "White"
+// NOTE: The line below is a shortcut syntax for the explicit syntax of the line above
+* us-core-race.ombCategory[0].valueCoding = RACE#2160-3 "White"
+* us-core-race.ombCategory[1].valueCoding = RACE#1002-5 "American Indian or Alaska Native"
+* us-core-race.ombCategory[2].valueCoding = RACE#2028-9 "Asian"
+* us-core-race.detailed[0].valueCoding = RACE#1586-7 "Shoshone"
+* us-core-race.detailed[1].valueCoding = RACE#2036-2 "Filipino"
+* us-core-race.text.valueString = "Mixed"
+* us-core-ethnicity.ombCategory.valueCoding = RACE#2135-2 "Hispanic or Latino"
+* us-core-ethnicity.detailed[0].valueCoding = RACE#2184-0 "Dominican"
+* us-core-ethnicity.detailed[1].valueCoding = RACE#2148-5 "Mexican"
+* us-core-ethnicity.text.valueString = "Hispanic or Latino"
+* us-core-birthsex.valueCode = #F
 * identifier.use = #usual
 * identifier.type.coding = MR#MR "Medical Record Number"
 * identifier.type.text = "Medical Record Number"

--- a/samples/USCorePediatricBMIForAge.fsh
+++ b/samples/USCorePediatricBMIForAge.fsh
@@ -8,6 +8,11 @@ Description:    """
     Defines constraints and extensions on the Observation resource for use 
     in querying and retrieving pediatric BMI observations."""
 // publisher, contact, jurisdiction, other metadata here
+// NOTE: MS can also be done in multiple lines:
+// * valueQuantity.value MS
+// * valueQuantity.unit MS
+// ...
+* valueQuantity.value, valueQuantity.unit, valueQuantity.system, valueQuantity.code MS
 * code ^short = "BMI percentile per age and sex for youth 2-20"
 * code.coding 1..*
 * code.coding.system 1..1
@@ -15,10 +20,10 @@ Description:    """
 * code.coding = LOINC#59576-9
 * value[x] only valueQuantity
 * valueQuantity 1..1
-* valueQuantity.value 1..1 MS
-* valueQuantity.unit 1..1 MS
-* valueQuantity.system 1..1 MS
+* valueQuantity.value 1..1
+* valueQuantity.unit 1..1
+* valueQuantity.system 1..1
 * valueQuantity.system = "http://unitsofmeasure.org"
-* valueQuantity.code 1..1 MS
+* valueQuantity.code 1..1
 * valueQuantity.code = #%
 * valueQuantity.code ^short = "Coded responses from the common UCUM units for vital signs value set."

--- a/samples/USCorePractitioner.fsh
+++ b/samples/USCorePractitioner.fsh
@@ -4,10 +4,14 @@ Id:             us-core-practitioner
 Title:          "US Core Practitioner"
 Description:    "The practitioner(s) referenced in US Core profiles."
 // publisher, contact, jurisdiction, other metadata here
-* identifier 1..* MS
+// NOTE: MS can also be done in multiple lines:
+// * identifier MS
+// * name MS
+// ...
+* identifier, identifier[NPI].system, name, name.family MS
+* identifier 1..*
 * identifier contains NPI 0..1 MS
-* identifier[NPI].system MS
 * identifier[NPI].system = "http://hl7.org/fhir/sid/us-npi"
 * identifier[NPI].system ^short = "The namespace for the identifier value"
-* name 1..* MS
-* name.family 1..1 MS
+* name 1..*
+* name.family 1..1

--- a/samples/USCorePulseOximetry.fsh
+++ b/samples/USCorePulseOximetry.fsh
@@ -8,31 +8,32 @@ Description:    """
     Defines constraints and extensions on the Observation resource for use in 
     querying and retrieving inspired O2 by pulse oximetry observations."""
 // publisher, contact, jurisdiction, other metadata here
-* code MS
+// NOTE: MS can also be done in multiple lines:
+// * code MS
+// * code.coding MS
+// ...
+* code, code.coding, code.coding[PulseOx].system, code.coding[PulseOx].code,
+  component[FlowRate].valueQuantity, component[FlowRate].valueQuantity.value,
+  component[FlowRate].valueQuantity.unit, component[FlowRate].valueQuantity.system
+  component[FlowRate].valueQuantity.code, component[Concentration].code,
+  component[Concentration].valueQuantity, component[Concentration].valueQuantity.value,
+  component[Concentration].valueQuantity.unit, component[Concentration].valueQuantity.system,
+  component[Concentration].valueQuantity.code MS
 * code ^short = "Oxygen Saturation by Pulse Oximetry"
-* code.coding MS
 * code.coding contains PulseOx 1..1 MS
-* code.coding[PulseOx].system MS
-* code.coding[PulseOx].code MS
 * code.coding[PulseOx] = LOINC#59408-5
 * component contains FlowRate 0..1 MS and Concentration 0..1 MS
 * component[FlowRate] ^short = "Inhaled oxygen flow rate"
 * component[FlowRate].code = LOINC#3151-8
 * component[FlowRate].value[x] only Quantity
-* component[FlowRate].valueQuantity MS
-* component[FlowRate].valueQuantity.value MS
-* component[FlowRate].valueQuantity.unit MS
-* component[FlowRate].valueQuantity.system 1..1 MS
+* component[FlowRate].valueQuantity.system 1..1
 * component[FlowRate].valueQuantity.system = "http://unitsofmeasure.org"
-* component[FlowRate].valueQuantity.code 1..1 MS
+* component[FlowRate].valueQuantity.code 1..1
 * component[FlowRate].valueQuantity.code = "l/min"
-* component[Concentration].code MS
 * component[Concentration].code = LOINC#3150-0
 * component[Concentration].value[x] only Quantity
-* component[Concentration].valueQuantity MS
-* component[Concentration].valueQuantity.value MS
-* component[Concentration].valueQuantity.unit MS
-* component[Concentration].valueQuantity.system 1..1 MS
+* component[Concentration].valueQuantity
+* component[Concentration].valueQuantity.system 1..1
 * component[Concentration].valueQuantity.system = "http://unitsofmeasure.org"
-* component[Concentration].valueQuantity.code 1..1 MS
+* component[Concentration].valueQuantity.code 1..1
 * component[Concentration].valueQuantity.code = "%"


### PR DESCRIPTION
This adds nice syntactical shortcuts to the samples:
* One line MS
* Dropping `extension`, so `extension[us-core-race].extension[ombCategory][0].valueCoding` -> `us-core-race.ombCategory[0].valueCoding`