### PR TITLE
Update Invariant rule documentation

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -440,7 +440,7 @@ Here is a summary of the rules supported in FSH:
 | Flag assignment | `* {path} {flag1} {flag2}` <br/> `* {path1}, {path2}, {path3}... {flag}` |
 | Extensions | `* {extension element path} contains {extensionName1} {card1} {flags1} and {extensionName2} {card2} {flags2}...` |
 | Slicing | `* {array element path} contains {sliceName1} {card1} {flags1} and {sliceName2} {card2} {flags2}...` |
-| 🚧 Invariants | `* obeys {invariant}` <br/> `* {path} obeys {invariant}` <br/> `* obeys {invariant1} and {invariant2} ...` <br/> `* {path} obeys {invariant1} and {invariant2} ...` |
+| Invariants | `* obeys {invariant}` <br/> `* {path} obeys {invariant}` <br/> `* obeys {invariant1} and {invariant2} ...` <br/> `* {path} obeys {invariant1} and {invariant2} ...` |
 | 🚫 Mapping | `* {path} -> {string}` |
 {: .grid }
 
@@ -759,7 +759,7 @@ One way to specify the slicing logic parameters is to use [structure definition 
 
 #### Invariant Rules
 
-🚧 [Invariants](https://www.hl7.org/fhir/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath expressions](https://www.hl7.org/fhir/fhirpath.html). An invariant can apply to an instance as a whole or a single element. Multiple invariants can be applied to an instance as a whole or to a single element. The FSH grammars for applying invariants in profiles are as follows:
+[Invariants](https://www.hl7.org/fhir/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath expressions](https://www.hl7.org/fhir/fhirpath.html). An invariant can apply to an instance as a whole or a single element. Multiple invariants can be applied to an instance as a whole or to a single element. The FSH grammars for applying invariants in profiles are as follows:
 
 `* obeys {invariant}`
 
@@ -819,7 +819,7 @@ This section shows how to define various items in FSH:
 * [Code Systems](#defining-code-systems)
 * 🚫 [Mappings](#defining-mappings)
 * 🚧 [Mixins](#defining-mixins)
-* 🚧 [Invariants](#defining-invariants)
+* [Invariants](#defining-invariants)
 
 #### Keywords
 
@@ -842,25 +842,25 @@ The use of individual keywords is explained in greater detail in the following s
 | `Alias`| Defines an alias for a URL or OID | uri, url, or oid  |
 | `CodeSystem` | Declares a new code system | name |
 | `Description` | Provides a human-readable description | string, markdown |
-| 🚧 `Expression` | The FHIR path expression in an invariant | string |
+| `Expression` | The FHIR path expression in an invariant | string |
 | `Extension` | Declares a new extension | name |
 | `Id` | Set a unique identifier of an item | name |
 | `Instance` | Declare a new instance | name |
 | `InstanceOf` | The profile or resource an instance instantiates | name |
-| 🚧 `Invariant` | Declares a new invariant | name |
+| `Invariant` | Declares a new invariant | name |
 | 🚧 `Mapping` | Introduces a new mapping | name |
 | 🚧 `Mixin` | Introduces a class to be used as a mixin | name |
 | 🚧 `Mixins` | Declares mix-in constraints in a profile | name or names (comma separated) |
 | 🚫 `Language` | Declares the language of texts in a localization file | language ISO code |
 | `Parent` | Specifies the base class for a profile or extension | name |
 | `Profile` | Introduces a new profile | name |
-| 🚧 `Severity` | error, warning, or guideline in invariant | code |
+| `Severity` | error, warning, or guideline in invariant | code |
 | 🚧 `Slice` | Introduces a new slice | name, string |
 | 🚫 `Source` | Profile or path a mapping applies to | path |
 | 🚫 `Target` | The standard that the mapping maps to | string |
 | `Title` | Short human-readable name | string |
 | `ValueSet` | Declares a new value set | name |
-| 🚧 `XPath` | the xpath in invariant | string |
+| `XPath` | the xpath in invariant | string |
 {: .grid }
 
 #### Defining Aliases
@@ -1222,7 +1222,7 @@ Mixins give you the capability to define that metadata once and apply it in as m
 
 #### Defining Invariants
 
-🚧 Invariants are defined using the keywords `Invariant`, `Id`, `Description`, `Expression`, `Severity`, and `XPath`. An invariant definition does not have any rules.
+Invariants are defined using the keywords `Invariant`, `Id`, `Description`, `Expression`, `Severity`, and `XPath`. An invariant definition does not have any rules.
 
 **Example:**
 ```

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -440,7 +440,7 @@ Here is a summary of the rules supported in FSH:
 | Flag assignment | `* {path} {flag1} {flag2}` <br/> `* {path1}, {path2}, {path3}... {flag}` |
 | Extensions | `* {extension element path} contains {extensionName1} {card1} {flags1} and {extensionName2} {card2} {flags2}...` |
 | Slicing | `* {array element path} contains {sliceName1} {card1} {flags1} and {sliceName2} {card2} {flags2}...` |
-| 🚧 Invariants | `* obeys {invariant}` <br/> `* {path} obeys {invariant}` <br/> `* {path1}, {path2}, ... obeys {invariant}` |
+| 🚧 Invariants | `* obeys {invariant}` <br/> `* {path} obeys {invariant}` <br/> `* obeys {invariant1} and {invariant2} ...` <br/> `* {path} obeys {invariant1} and {invariant2} ...` |
 | 🚫 Mapping | `* {path} -> {string}` |
 {: .grid }
 
@@ -759,15 +759,17 @@ One way to specify the slicing logic parameters is to use [structure definition 
 
 #### Invariant Rules
 
-🚧 [Invariants](https://www.hl7.org/fhir/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath expressions](https://www.hl7.org/fhir/fhirpath.html). An invariant can apply to an instance as a whole, a single element, or multiple elements. The FSH grammars for applying invariants in profiles are as follows:
+🚧 [Invariants](https://www.hl7.org/fhir/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath expressions](https://www.hl7.org/fhir/fhirpath.html). An invariant can apply to an instance as a whole or a single element. Multiple invariants can be applied to an instance as a whole or to a single element. The FSH grammars for applying invariants in profiles are as follows:
 
 `* obeys {invariant}`
 
 `* {path} obeys {invariant}`
 
-`* {path1}, {path2}, ... obeys {invariant}`
+`* obeys {invariant1} and {invariant2} ...`
 
-The first case is where the invariant applies to the profile as a whole. The second is where the invariant applies to a single element, and the third is where the invariant applies to multiple elements.
+`* {path} obeys {invariant1} and {invariant2} ...`
+
+The first case is where the invariant applies to the profile as a whole. The second is where the invariant applies to a single element. The third case is where multiple invariants apply to the profile as a whole, and the fourth is where multiple invariants apply to a single element.
 
 The referenced invariant and its properties must be declared somewhere within the same FSH tank, using the `Invariant` keyword. See [Defining Invariants](#defining-invariants).
 


### PR DESCRIPTION
This updates the documentation on Invariants with two changes:

- Invariants can be added to the profile as a whole or to a single element, meaning 0 or 1 paths can be specified in the rule.
- Multiple invariants can be applied to the specified path, meaning 1 to many invariants can be specified in the rule.