### PR TITLE
Updates to Language Reference

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -35,7 +35,33 @@ FSH has a number of Keywords and reserved words (e.g., `Alias`, `Profile`, `Exte
 
 The primitive data types and value formats in FSH are identical to the [primitive types and value formats in FHIR](https://www.hl7.org/fhir/datatypes.html#primitive).
 
-For convenience, FSH also supports multi-line strings, demarcated with triple double quotation marks `"""`. The line breaks are for visual convenience only, and multi-line strings are translated to conventional FHIR strings.
+##### Multi-line Strings
+
+For convenience, FSH also supports multi-line strings, demarcated with three double quotation marks `"""`. This feature allows for authors to split text over multiple lines and indent it as appropriate to retain visual consistency in the FSH file.  When processing multi-line strings, the following approach is followed:
+* If the first line contains only whitespace (including newline), discard it.
+* If the last line contains only whitespace (including newline), discard it.
+* If another line contains only whitespace, truncate it to zero characters.
+* For all other non-whitespace lines, detect the shortest number of leading spaces and trim that from the beginning of every line.
+
+For example, an author might use a multi-line string to write markdown so that the markdown can be indented inside the FSH:
+```
+* ^purpose = """
+    * This profile is intended to support workflows where:
+      * this happens; or
+      * that happens
+    * This profile is not intended to support workfows where:
+      * nothing happens
+  """
+```
+
+Using a normal string would require the following spacing to accomplish the same markdown formatting:
+```
+* ^purpose = "* This profile is intended to support workflows where:
+  * this happens; or
+  * that happens
+* This profile is not intended to support workfows where:
+  * nothing happens"
+```
 
 #### Whitespace
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1189,19 +1189,6 @@ Mixins give you the capability to define that metadata once and apply it in as m
   Mixins: FranceObservationMixin
  ```
 
- **External Mixins**
-
- 🚫 The ability to add external mixins is not yet supported. When supported, this should expand the functionality of the `Mixins` keyword to accept other internally or externally defined profiles or extensions as arguments. Since the profile or extension may be externally defined, we must be able to mix the contents of one Structure Definition onto another. The order of application will be inheritance, then mixins, then rules. For example if we had this FSH:
- ```
- Profile: SuperSpecialPatient
- Parent: SuperPatient
- Mixins: SpecialPatient
- * {rule1}
- * {rule2}
- // More rules
- ```
- First the `SuperSpecialPatient` would inherit from `SuperPatient`. Then the definition of `SpecialPatient` would be merged in. Finally, the rules `rule1` and `rule2` and any more rules would be applied.
-
 #### Defining Invariants
 
 Invariants are defined using the keywords `Invariant`, `Id`, `Description`, `Expression`, `Severity`, and `XPath`. An invariant definition does not have any rules.

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -11,7 +11,6 @@ This document describes the FSH language.
 | {curly braces} | An item to be substituted | `{codesystem}#{code}` |
 | **bold** | Emphasis |  Do **not** ignore this. |
 | 🚧 | Indicates a feature implemented in FSH but not yet implemented in SUSHI | |
-| 🚫 | Indicates a planned feature, not yet implemented in FSH or SUSHI | |
 
 #### Versioning
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -780,7 +780,7 @@ Future versions of FHIR Shorthand may support standalone slice definitions, but 
 
 `* {path} obeys {invariant1} and {invariant2} ...`
 
-The first case is where the invariant applies to the profile as a whole. The second is where the invariant applies to a single element. The third case is where multiple invariants apply to the profile as a whole, and the fourth is where multiple invariants apply to a single element.
+The first case applies the invariant to the profile as a whole. The second case applies the invariant to a single element. The third case applies multiple invariants to the profile as a whole, and the fourth case applies multiple invariants to a single element.
 
 The referenced invariant and its properties must be declared somewhere within the same [FSH tank](index.html#fsh-tanks), using the `Invariant` keyword. See [Defining Invariants](#defining-invariants).
 
@@ -790,7 +790,7 @@ The referenced invariant and its properties must be declared somewhere within th
 
   `* obeys us-core-9`
 
-* Assign invariant to Patient.name in US Core:
+* Assign invariant to Patient.name in US Core Patient:
 
   `* name obeys us-core-8`
 
@@ -1191,15 +1191,14 @@ Mixins give you the capability to define that metadata once and apply it in as m
 
 #### Defining Invariants
 
-Invariants are defined using the keywords `Invariant`, `Id`, `Description`, `Expression`, `Severity`, and `XPath`. An invariant definition does not have any rules.
+Invariants are defined using the keywords `Invariant`, `Description`, `Expression`, `Severity`, and `XPath`. An invariant definition does not have any rules.
 
 **Example:**
 ```
-Invariant:  USCoreNameInvariant
-Id:         us-core-8
-Definition: "Patient.name.given  or Patient.name.family or both SHALL be present"
+Invariant:  us-core-8
+Definition: "Patient.name.given or Patient.name.family or both SHALL be present"
 Expression: "family.exists() or given.exists()"
-Severity:   "error"
+Severity:   #error
 XPath:      "f:given or f:family"
 ```
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -401,7 +401,7 @@ Here is a summary of the rules supported in FSH:
 | --- | --- |
 | Fixed value |`* {path} = {value}`  | 
 | Value set binding |`* {path} from {valueSet} ({strength})`| 
-| Narrowing cardinality | `* {path} {min}..{max}` |
+| Narrowing cardinality | `* {path} {min}..{max}` <br/>`* {path} {min}..` <br/>`* {path} ..{max}` |
 | Data type restriction | `* {path} only {type1} or {type2} or {type3}` |
 | Reference type restriction | `* {path} only Reference({type1} | {type2} | {type3})` |
 | Flag assignment | `* {path} {flag1} {flag2}` <br/> `* {path1}, {path2}, {path3}... {flag}` |
@@ -489,7 +489,7 @@ To change the cardinality, the grammar is:
 
 `* {path} {min}..{max}`
 
-As in FHIR, min and max are non-negative integers, and max can also be *, representing unbounded.
+As in FHIR, min and max are non-negative integers, and max can also be *, representing unbounded. It is valid (and even encouraged) to include both the min and max, even if one of them remains the same as in the original cardinality. In this case, FSH processors (e.g., SUSHI) should only generate constraints for the changed values. FSH also supports one-sided cardinalities if the author wishes to omit an unconstrained min or max in the expression.
 
 Cardinalities must follow [rules of FHIR profiling](https://www.hl7.org/fhir/conformance-rules.html#cardinality), namely that the min and max cardinalities must stay within the constraints of the parent.
 
@@ -502,6 +502,14 @@ Cardinalities must follow [rules of FHIR profiling](https://www.hl7.org/fhir/con
 * Set the cardinality of a sub-element to 0..0 (not permitted):
 
   `* component.referenceRange 0..0`
+
+* 🚧 Require at least one category without changing its upper bound (*):
+
+  `* category 1..`
+
+* 🚧 Allow at most one category without changing its lower bound (0):
+
+  `* category ..1`
 
 #### Data Type Restriction Rules
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -10,14 +10,13 @@ This document describes the FSH language.
 | ' ' (single quotes) | Used to highlight a literal value | the code 'confirmed'|
 | {curly braces} | An item to be substituted | `{codesystem}#{code}` |
 | **bold** | Emphasis |  Do **not** ignore this. |
-| 🚧 | Indicates a feature implemented in FSH but not yet implemented in SUSHI | |
 {: .grid }
 
 #### Versioning
 
 The FSH specification, like other IGs, follows the [semantic versioning](https://semver.org) convention (MAJOR.MINOR.PATCH):
 
-* MAJOR: A major release has significant new functionality and potentially has grammar changes or other non-backward-compatible changes.
+* MAJOR: A major release has significant new functionality and, potentially, grammar changes or other non-backward-compatible changes.
 * MINOR: Contains new or modified features, while maintaining backwards compatibility within the major version.
 * PATCH: Contains minor updates and bug fixes, while maintaining backwards compatibility within the major version.
 
@@ -37,9 +36,8 @@ The primitive data types and value formats in FSH are identical to the [primitiv
 
 ##### Multi-line Strings
 
-For convenience, FSH also supports multi-line strings, demarcated with three double quotation marks `"""`. This feature allows for authors to split text over multiple lines and indent it as appropriate to retain visual consistency in the FSH file.  When processing multi-line strings, the following approach is followed:
-* If the first line contains only whitespace (including newline), discard it.
-* If the last line contains only whitespace (including newline), discard it.
+For convenience, FSH also supports multi-line strings, demarcated with three double quotation marks `"""`. This feature allows for authors to split text over multiple lines and retain consistent indentation in the FSH file. When processing multi-line strings, the following approach is followed:
+* If the first line or last line contains only whitespace (including newline), discard it.
 * If another line contains only whitespace, truncate it to zero characters.
 * For all other non-whitespace lines, detect the shortest number of leading spaces and trim that from the beginning of every line.
 
@@ -49,7 +47,7 @@ For example, an author might use a multi-line string to write markdown so that t
     * This profile is intended to support workflows where:
       * this happens; or
       * that happens
-    * This profile is not intended to support workfows where:
+    * This profile is not intended to support workflows where:
       * nothing happens
   """
 ```
@@ -59,7 +57,7 @@ Using a normal string would require the following spacing to accomplish the same
 * ^purpose = "* This profile is intended to support workflows where:
   * this happens; or
   * that happens
-* This profile is not intended to support workfows where:
+* This profile is not intended to support workflows where:
   * nothing happens"
 ```
 
@@ -207,50 +205,52 @@ To set the top-level text of a CodeableConcept, the shorthand expression is:
 
 ##### Quantity
 
-In addition to having a quantitative value, a FHIR Quantity has a coded value that is interpreted as the units of measure. As such, a Quantity can be bound to a value set or assigned a coded value. The shorthand is:
+FSH provides a shorthand that allows quantities with units of measure to be specified simultaneously, provided the units of measure are [Unified Code for Units of Measure](http://unitsofmeasure.org/) (UCUM) codes. The syntax is:
+
+`* {Quantity type} = {number} '{valid UCUM unit}'`
+
+This syntax is borrowed from the [Clinical Quality Language](https://cql.hl7.org) (CQL).
+
+The value and units can also be set independently. To set the value of quantity value, the quantity `value` property can be set directly:
+
+`* {Quantity type}.value = {number}`
+
+To set the units of measure independently, a Quantity can be bound to a value set or assigned a coded value. The shorthand is:
 
 `* {Quantity type} = {system}#{code} "{display text}"`
 
-Although this appears like the quantity is being set to a coded value, it is legal and sets only the coded units part of the quantity. 
+Although it appears the quantity itself is being set to a coded value, this expression sets only the units of measure. To make this more intuitive, FSH allows you to use the word `units`, as follows:
 
-🚧 To make this a bit more intuitive, FSH allows you to use the word `units`, as follows:
+🚧 `* {Quantity type} units = {system}#{code} "{display text}"`
 
-`* {Quantity type} units = {system}#{code} "{display text}"`
+and for [binding](#value-set-binding-rules):
 
-🚧 and for [binding](#value-set-binding-rules):
-
-`* {Quantity type} units from {value set} ({strength})`
+🚧 `* {Quantity type} units from {value set} ({strength})`
 
 >**Note:** Use of the word `units` is suggested for clarity, but is optional.
 
-To set an actual quantity value, the quantity `value` property can be set directly. In addition, FHIR Shorthand allows quantity values to be specified "[CQL-style](https://cql.hl7.org)" by providing a number followed by a single-quoted UCUM unit.  The shorthand for this syntax is:
-
-`* {Quantity type} = {number} '{valid ucum unit}'`
-
 **Examples:**
 
-* Set the units of the valueQuantity of an Observation to millimeters (assuming UCUM has been defined as an alias for http://unitsofmeasure.org):
+* Set the valueQuantity of an Observation to 55 millimeters using UCUM units:
+
+  `* valueQuantity = 55.0 'mm'`
+
+* Set the numerical value of Observation.valueQuantity to 55.0 without setting the units:
+
+  `* valueQuantity.value = 55.0`
+
+* Set the units of the same valueQuantity to millimeters, without setting the value (assuming UCUM has been defined as an alias for http://unitsofmeasure.org):
 
   `* valueQuantity = UCUM#mm "millimeters"`
 
-* 🚧 Alternate syntax for the same operation (addition of 'units'):
+* Alternate syntax for the same operation (addition of the word `units`):
 
   `* valueQuantity units = UCUM#mm "millimeters"`
 
-* 🚧 Bind a value set to the units of a Quantity (using alternate syntax):
+* Bind a value set to the units of the same quantity (using alternate syntax):
 
   `* valueQuantity units from http://hl7.org/fhir/ValueSet/distance-units`
 
-* Set the valueQuantity of an observation to 55 millimeters using the separate value property:
-
-  ```
-  * valueQuantity = UCUM#mm "millimeters"
-  * valueQuantity.value = 55
-  ```
-
-* Set the valueQuantity of an observation to 55 millimeters using the CQL-style syntax:
-
-  `* valueQuantity = 55 'mm'`
 
 #### Paths
 
@@ -506,7 +506,7 @@ For convenience and compactness, cardinality rules can be combined with [flag as
 
   `* subject 1..1`
 
-* Set the cardinality of the subject element to 1..1 and declare it as Must Support:
+* Set the cardinality of the subject element to 1..1 and declare it Must Support:
 
   `* subject 1..1 MS`
 
@@ -655,7 +655,7 @@ In both styles, the cardinality is required, and flags are optional. Adding an e
 
   ...
 
-  // FSH definition of Laterality (for example)
+  // Definition of Laterality used as standalone extension
   Extension: Laterality
   Description: "Body side of a body location."
   * value[x] only CodeableConcept
@@ -757,7 +757,7 @@ Reslicing (slicing an existing slice) uses a similar syntax, but the left-hand s
 
 At a minimum, each slice must be constrained such that it can be uniquely identified via the discriminator. For example, if the discriminator points to a "code" path that is a CodeableConcept, and it discriminates by "pattern", then each slice must have a constraint on "code" that uniquely distinguishes it from the other slices' codes. In addition to this minimum requirement, authors often place additional constraints on other aspects of each slice.
 
-Future versions of FHIR Shorthand may support standalone slice definitions, but FHIR Shorthand version 1.0 requires slice contents to be defined inline. The syntax for inline definition of slices is the same as constraining any other path in a profile, but uses the [slice path syntax](#sliced-array-paths) in the path:
+Future versions of FHIR Shorthand may support standalone slice definitions, but FHIR Shorthand version 1.0 requires slice contents to be defined inline. The rule syntax for inline slices is the same as constraining any other path in a profile, but uses the [slice path syntax](#sliced-array-paths) in the path:
 
 ```
 * {path to slice}.{subpath} {constraint}
@@ -823,7 +823,7 @@ In FSH, mapping rules are not included in the profile definition.  Rather, they 
 
   `* identifier.value -> "Patient.identifier.value"`
 
->**Note:** Unlike setting the mapping dmappingirectly in the SD, mapping rules within a Mapping item do not include the name of the resource in the path on the left hand side.
+>**Note:** Unlike setting the mapping directly in the SD, mapping rules within a Mapping item do not include the name of the resource in the path on the left hand side.
 
 ***
 
@@ -889,7 +889,7 @@ Alias definitions follow this syntax:
 
 `Alias: {AliasName} = {url or oid}`
 
-In contrast with other names in FSH (for profiles, extensions, etc.), aliases can begin with dollar sign ($).
+In contrast with other names in FSH (for profiles, extensions, etc.), aliases can begin with a dollar sign ($).
 
 If you choose a name beginning with a dollar sign, then additional error checks can be carried out. Specifically, if a rule involves a $name, it can only be an alias. If there is no corresponding alias definition, an error can be signalled.
 
@@ -1061,7 +1061,7 @@ Not all operators are valid for any code system. The `property` and `value` are 
 * Explicit ([extensional](https://www.hl7.org/fhir/valueset.html#int-ext)) value set:
 
 ```
-ValueSet:    BodyWeightPreconditionVS
+ValueSet: BodyWeightPreconditionVS
 Title: "Body weight preconditions."
 Description:  "Circumstances for body weight measurement."
 * SCT#971000205103 "Wearing street clothes with shoes"
@@ -1137,7 +1137,7 @@ In the example above, the target is another FHIR profile, but in many cases, the
 
 #### Defining Rule Sets
 
-🚧 Rule sets provide the ability to define rules and apply (or "mixin") them to a compatible target. The rules are copied from the rule set at compile time. Profiles, extensions, and instances can have one or more rule sets applied to them. The same rule set can be used in multiple places.
+🚧 Rule sets provide the ability to define rules and apply them ("mix in") to a compatible target. The rules are copied from the rule set at compile time. Profiles, extensions, and instances can have one or more rule sets applied to them. The same rule set can be used in multiple places.
 
 Rule sets are defined by using the keyword `RuleSet`:
 ```
@@ -1159,7 +1159,7 @@ Currently only rule sets can be mixed into profiles and extensions, but future v
 **Examples:**
 Defining and using a mixin for metadata shared in all US Core Profiles:
 ```
-  Mixin: USCoreMetadata
+  RuleSet: USCoreMetadata
   * ^version = "3.1.0"
   * ^status = #active
   * ^experimental = false
@@ -1178,7 +1178,6 @@ The `MyUSCorePatientProfile` defined above is equivalent to the following:
 ```
   Profile: MyUSCorePatientProfile
   Parent: Patient
-  Mixins: USCoreMetadata
   * ^version = "3.1.0"
   * ^status = #active
   * ^experimental = false
@@ -1193,11 +1192,11 @@ Mixins give you the capability to define that metadata once and apply it in as m
 ```
   Profile: USCoreBreastRadiologyProfile
   Parent: BreastRadiologyProfile
-  Mixins:  USCoreMetadata, USObservationMixin
+  Mixins:  USObservationRuleSet
 
   Profile: FranceBreastRadiologyProfile
   Parent: BreastRadiologyProfile
-  Mixins: FranceObservationMixin
+  Mixins: FranceObservationRuleSet
  ```
 
 #### Defining Invariants

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -827,7 +827,7 @@ This section shows how to define various items in FSH:
 * [Value Sets](#defining-value-sets)
 * [Code Systems](#defining-code-systems)
 * [Mappings](#defining-mappings)
-* [Mixins](#defining-mixins)
+* [Rule Sets](#defining-rule-sets)
 * [Invariants](#defining-invariants)
 
 #### Keywords
@@ -858,10 +858,10 @@ The use of individual keywords is explained in greater detail in the following s
 | `InstanceOf` | The profile or resource an instance instantiates | name |
 | `Invariant` | Declares a new invariant | name |
 | 🚧 `Mapping` | Declares a new mapping | name |
-| `Mixin` | Introduces a class to be used as a mixin | name |
 | `Mixins` | Declares mix-in constraints in a profile | name or names (comma separated) |
 | `Parent` | Specifies the base class for a profile or extension | name |
 | `Profile` | Introduces a new profile | name |
+| `RuleSet` | Declares a set of rules to be used as a mixin | name |
 | `Severity` | error, warning, or guideline in invariant | code |
 | `Source` | Profile or path a mapping applies to | path |
 | `Target` | The standard that the mapping maps to | string |
@@ -1124,23 +1124,26 @@ To create a mapping, the keywords `Mapping`, `Source`, `Target` and `Id` are use
 
 In the example above, the target is another FHIR profile, but in many cases, the target will not use FHIR. For this reason, the right-hand side of mapping statements is always a string in order to allow the greatest flexibility. For this same reason, even though the target is FHIR in the example above, FSH cannot make any assumptions about how the individual target values work; thus the resource name "Patient" is included in the right-hand side values since this is how the mapping targets should be expressed in the SD.
 
+#### Defining Rule Sets
 
-🚧  Mixins provide the ability to define rules and apply them to a compatible target. The rules are copied from the mixin at compile time. Profiles, extensions, and instances can all have multiple mixins applied to them. One mixin can be used in multiple different places.
+🚧 Rule sets provide the ability to define rules and apply (or "mixin") them to a compatible target. The rules are copied from the rule set at compile time. Profiles, extensions, and instances can have one or more rule sets applied to them. The same rule set can be used in multiple places.
 
-At present, mixins must be defined in FSH. The capability for mixing in external definitions is under developement. Mixins are defined by using the keyword `Mixin`.
+Rule sets are defined by using the keyword `RuleSet`:
 ```
-Mixin: {MixinName}
+RuleSet: {RuleSetName}
 * {rule1}
 * {rule2}
 // More rules
 ```
-A mixin is used to define a group of rules. These rules are then included using the keyword `Mixins`.
+A defined rule set can be applied to an item by using the keyword `Mixins`:
 ```
 Profile: MyPatientProfile
 Parent: Patient
-Mixins: {Mixin1}, {Mixin2}
+Mixins: {RuleSet1}, {RuleSet2}
 ```
-Each mixin should be compatible with the target, in the sense that all the rules defined in the mixin apply to elements actually present in the target. The legality of a mixin is checked at compile time. If a particular rule from a mixin applies to an element not present on the target, that rule will not be applied, and an error will be emitted. However, all other valid rules from the mixin will still be applied. The rules from a mixin are applied **before** rules defined on the target itself. When multiple mixins are included using the `Mixins` keyword, the mixin rules are applied in the order that the mixins are listed.
+Each rule set should be compatible with the target, in the sense that all the rules defined in the rule set apply to elements actually present in the target. The legality of a rule set is checked at compile time. If a particular rule from a rule set does not match an element in the target, that rule will not be applied, and an error will be emitted. However, all other valid rules from the rule set will still be applied. The rules from a rule set are applied **before** rules defined on the target itself. When multiple rule sets are included using the `Mixins` keyword, the rule set rules are applied in the order that the rule sets are listed.
+
+Currently only rule sets can be mixed into profiles and extensions, but future versions of FHIR Shorthand may allow external definitions (such as other profiles and extensions) to be mixed in as well.
 
 **Examples:**
 Defining and using a mixin for metadata shared in all US Core Profiles:

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -209,7 +209,7 @@ In addition to having a quantitative value, a FHIR Quantity has a coded value th
 
 `* {Quantity type} = {system}#{code} "{display text}"`
 
-Although this appears the quantity is being set to a coded value, it is legal. 
+Although this appears like the quantity is being set to a coded value, it is legal and sets only the coded units part of the quantity. 
 
 🚧 To make this a bit more intuitive, FSH allows you to use the word `units`, as follows:
 
@@ -221,7 +221,9 @@ Although this appears the quantity is being set to a coded value, it is legal.
 
 >**Note:** Use of the word `units` is suggested for clarity, but is optional.
 
+To set an actual quantity value, the quantity `value` property can be set directly. In addition, FHIR Shorthand allows quantity values to be specified "[CQL-style](https://cql.hl7.org)" by providing a number followed by a single-quoted UCUM unit.  The shorthand for this syntax is:
 
+`* {Quantity type} = {number} '{valid ucum unit}'`
 
 **Examples:**
 
@@ -236,6 +238,17 @@ Although this appears the quantity is being set to a coded value, it is legal.
 * 🚧 Bind a value set to the units of a Quantity (using alternate syntax):
 
   `* valueQuantity units from http://hl7.org/fhir/ValueSet/distance-units`
+
+* Set the valueQuantity of an observation to 55 millimeters using the separate value property:
+
+  ```
+  * valueQuantity = UCUM#mm "millimeters"
+  * valueQuantity.value = 55
+  ```
+
+* Set the valueQuantity of an observation to 55 millimeters using the CQL-style syntax:
+
+  `* valueQuantity = 55 'mm'`
 
 #### Paths
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -796,24 +796,23 @@ The referenced invariant and its properties must be declared somewhere within th
 
 #### Mapping Rules
 
-🚫 [Mappings](https://www.hl7.org/fhir/mappings.html) are an optional part of SDs that can be provided to help implementers understand the content and use resources correctly. These mappings are informative and are not to be confused with the computable mappings provided by [FHIR Mapping Language](https://www.hl7.org/fhir/mapping-language.html) and the [StructureMap resource](https://www.hl7.org/fhir/structuremap.html).
+🚧 [Mappings](https://www.hl7.org/fhir/mappings.html) are an optional part of SDs that can be provided to help implementers understand the content and use resources correctly. These mappings are informative and are not to be confused with the computable mappings provided by [FHIR Mapping Language](https://www.hl7.org/fhir/mapping-language.html) and the [StructureMap resource](https://www.hl7.org/fhir/structuremap.html).
 
-Mapping rules use the symbol `->` with the following grammar:
+In FSH, mapping rules are not included in the profile definition.  Rather, they are included in a separate [Mapping definition](#defining-mappings) that provides additional context such as the higher level source and target. Within that definition mapping rules use the symbol `->` with the following grammar:
 
 `* {path} -> {string}`
 
 **Examples:**
 
-* Map the entire profile to another item:
+* Map the entire profile to a Patient item in another specification:
 
   `* -> Patient`
 
-* Map the identifier.value element:
+* Map the identifier.value element from one IG to another:
 
-  `* identifier.value -> "identifier.value"`
+  `* identifier.value -> "Patient.identifier.value"`
 
-
->**Note:** Unlike setting the mapping directly in the SD, mapping rules within a Mapping do not include the name of the resource.
+>**Note:** Unlike setting the mapping dmappingirectly in the SD, mapping rules within a Mapping item do not include the name of the resource in the path on the left hand side.
 
 ***
 
@@ -858,7 +857,7 @@ The use of individual keywords is explained in greater detail in the following s
 | `Instance` | Declare a new instance | name |
 | `InstanceOf` | The profile or resource an instance instantiates | name |
 | `Invariant` | Declares a new invariant | name |
-| 🚫 `Mapping` | Introduces a new mapping | name |
+| 🚧 `Mapping` | Declares a new mapping | name |
 | `Mixin` | Introduces a class to be used as a mixin | name |
 | `Mixins` | Declares mix-in constraints in a profile | name or names (comma separated) |
 | `Parent` | Specifies the base class for a profile or extension | name |
@@ -1101,7 +1100,7 @@ Description:  "A brief vocabulary of yoga-related terms."
 
 #### Defining Mappings
 
-🚫 [Mappings to other standards](https://www.hl7.org/fhir/mappings.html) are an optional part of a SD. These mappings are informative and are provided to help implementers understand the content of the SD and use the profile or resource correctly. While it is possible for profile authors to include mappings using escape syntax, FSH provides a more modular approach.
+🚧 [Mappings to other standards](https://www.hl7.org/fhir/mappings.html) are an optional part of a SD. These mappings are informative and are provided to help implementers understand the content of the SD and use the profile or resource correctly. While it is possible for profile authors to include mappings using escape syntax, FSH provides a more modular approach.
 
 > **Note:** The informational mappings in SDs should not be confused with functional mappings provided by [FHIR Mapping Language](https://www.hl7.org/fhir/mapping-language.html) and the [StructureMap resource](https://www.hl7.org/fhir/structuremap.html).
 
@@ -1115,15 +1114,16 @@ To create a mapping, the keywords `Mapping`, `Source`, `Target` and `Id` are use
   Target:   "http://unknown.org/Argonaut-DQ-DSTU2"
   Id:       argonaut-dq-dstu2
   * -> Patient
-  * extension[USCoreRaceExtension] -> "extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-race]"
-  * extension[USCoreEthnicityExtension] -> "extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-ethnicity]"
-  * extension[USCoreBirthSexExtension] -> "extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-birthsex]"
-  * identifier -> "identifier"
-  * identifier.system -> "identifier.system"
-  * identifier.value -> "identifier.value"
+  * extension[USCoreRaceExtension] -> "Patient.extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-race]"
+  * extension[USCoreEthnicityExtension] -> "Patient.extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-ethnicity]"
+  * extension[USCoreBirthSexExtension] -> "Patient.extension[http://fhir.org/guides/argonaut/StructureDefinition/argo-birthsex]"
+  * identifier -> "Patient.identifier"
+  * identifier.system -> "Patient.identifier.system"
+  * identifier.value -> "Patient.identifier.value"
 ```
 
-#### Defining Mixins
+In the example above, the target is another FHIR profile, but in many cases, the target will not use FHIR. For this reason, the right-hand side of mapping statements is always a string in order to allow the greatest flexibility. For this same reason, even though the target is FHIR in the example above, FSH cannot make any assumptions about how the individual target values work; thus the resource name "Patient" is included in the right-hand side values since this is how the mapping targets should be expressed in the SD.
+
 
 🚧  Mixins provide the ability to define rules and apply them to a compatible target. The rules are copied from the mixin at compile time. Profiles, extensions, and instances can all have multiple mixins applied to them. One mixin can be used in multiple different places.
 


### PR DESCRIPTION
Like in the previous PR, this one was done in commits if you prefer to back out any wholesale changes related to specific features.  Or feel free to tack on a commit with your tweaks as before.

Additional thoughts as I reviewed this:

1. I left in the 🚧 icons for now, since we will merge this before all features are done in SUSHI -- but I assume that the final publication will have all 🚧 removed.
2. The IG Publisher's rendering of the angled "smart quotes" drives me crazy!
3. The heading levels don't seem right.  Should we really be starting at heading level `####`? It doesn't leave much room to go anywhere!
4. I think we should consider making all full-line code expressions use triple-tick code blocks.  The mix of single-tick and triple-tick code formatting looks sloppy to me.
5. I'm not sure that the formatting rules are consistently applied (e.g., "" vs. italics vs. code font vs. no text treatment at all).  I couldn't tell when resource names and/or properties should be "" or inline code text or what... 
6. Some of the keywords you identified as reserved aren't really reserved (for example, `Parent` isn't reserved, but `Parent:` is).
7. I think we should consider listing the reserved words instead of making readers parse the G4 file for them.
8. Should there be discussion in the section on fixing codes about when you should/shouldn't include a display?
9. We need to document `=` vs. `:=`.
10. In general, it might be helpful to be more clear about what examples are in the context of instances vs what examples are in the context of profiles.
11. I think we currently toss the display when fixing quantity units to a code (there is no "display" property on Quantity) -- but we could probably use it to set the "unit" property (whose description says it is the human-readable unit).  Thoughts?
12. The example for Profiled Type Choice Paths is _wrong_.  What the example is attempting to do would not work.  You can only do that via slicing.  I didn't remove it though because I had real trouble trying to come up w/ a valid use case for when you would use a path to a specific profile of a choice (without slicing).  Best I could come up w/ was constraining it to an even more specific profile...
13. I found at least one reference to package.json, but package.json might go away when we implement the new configuration.
14. We need to document `Usage:` for `Instance` definitions.
15. I wonder if this might benefit from restructuring.  As a user, I think I'd rather see it divided into sections: Profiles & Extensions, Value Sets, Code Systems, Instances, etc. -- and each section is fairly complete on its own in that it documents its own keywords *and* rules together. As it is now,  I need to skip all over that page to get a complete picture of how to build a profile... That said, that type of restructuring would be a lot of work at this point...