### PR TITLE
Edits to SUSHI, Tutorial, and Reference

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1224,8 +1224,8 @@ The `Usage` keyword specifies how the instance should be presented in the IG:
   * name.given[1] = "Steve"
   * name.family = "Anyperson"
   * birthDate = 1960-04-25
-  * us-core-race.ombCategory.valueCoding = RACE#2106-3 "White"
-  * us-core-ethnicity.ombCategory.valueCoding = RACE#21865 "Non Hispanic or Latino"
+  * extension[us-core-race].extension[ombCategory].valueCoding = RACE#2106-3 "White"
+  * extension[us-core-ethnicity].extension[ombCategory].valueCoding = RACE#21865 "Non Hispanic or Latino"
   ```
 
 * Define an instance of US Core Practitioner, with name and NPI, meant to be inlined in a composition:

--- a/input/pagecontent/sushi.md
+++ b/input/pagecontent/sushi.md
@@ -5,7 +5,7 @@ This reference manual is a comprehensive guide to the command line interface, au
 
 This guide assumes you have:
 
-* Reviewed the [FHIR Shorthand Tutorial](tutorial.html)
+* Reviewed the [FHIR Shorthand Tutorial](tutorial.html).
 * Created FSH files representing your profiles and other IG artifacts (see [Authoring Guide](index.html) and [FSH Language Reference](reference.html) for details).
 
 The following conventions are used:
@@ -20,7 +20,7 @@ The following conventions are used:
 
 | Symbol | Explanation |
 |:----------|:------|
-| 🍎 | Indicates information or command specific to OS X. The instructions assume the shell script is **bash**. As of the Mac Catalina release, the default is **zsh** and will need to be reconfigured as a default or at runtime to call bash shell. You can find out the default shell in a Mac terminal by running `echo $SHELL`.|
+| 🍎 | Indicates information or command specific to OS X. Commands can be run within the Terminal application. |
 | 💻 | Indicates information or command specific to Windows. A command window can be launched by typing `cmd` at the _Search Windows_ tool. |
 | $ | Represents command prompt (may vary depending on platform) |
 {: .grid }
@@ -57,7 +57,7 @@ Use `$ sushi -v` to display version of SUSHI
 
 SUSHI follows the [semantic versioning](https://semver.org) convention (MAJOR.MINOR.PATCH):
 
-* MAJOR: A major release has significant new functionality and potentially, grammar changes or other non-backward-compatible changes.
+* MAJOR: A major release has significant new functionality and, potentially, grammar changes or other non-backward-compatible changes.
 * MINOR: Contains new or modified features, while maintaining backwards compatibility within the major version.
 * PATCH: Contains minor updates and bug fixes, while maintaining backwards compatibility within the major version.
 
@@ -99,7 +99,7 @@ where options include:
 
 The options are not order-sensitive.
 
-> Note: By default, SUSHI only generates the [profile differential](https://www.hl7.org/fhir/profiling.html#snapshot), leaving it to the IG Publisher to create the [profile snapshot](https://www.hl7.org/fhir/profiling.html#snapshot). The `-s` option will cause SUSHI to generate the snapshot without having to run the IG Publisher.
+> Note: By default, SUSHI only generates the [profile differential](https://www.hl7.org/fhir/profiling.html#snapshot), leaving it to the IG Publisher to create the [profile snapshot](https://www.hl7.org/fhir/profiling.html#snapshot). This is the approach recommended by HL7 FHIR leadership. If authors prefer, the `-s` option can be used to cause SUSHI to generate the snapshot without having to run the IG Publisher.
 
 If you run SUSHI from the same directory where your .fsh files are located, and accept the defaults, the command can be shortened to:
 
@@ -109,14 +109,15 @@ $ sushi .
 
 #### Error Messages
 
-In the process of developing your IG using FSH, you may encounter SUSHI error messages (written to the command console). Most error messages point to a specific line or lines in a `.fsh` file. If possible, SUSHI will continue, despite errors, to produce FHIR artifacts, but those artifacts will omit any problematic rules. SUSHI should always exit gracefully. If SUSHI crashes, please report the issue using the [SUSHI issue tracker](https://github.com/FHIR/sushi/issues).
+In the process of developing your IG using FSH, you may encounter SUSHI error messages (written to the command console). Most error messages point to a specific line or lines in a `.fsh` file. If possible, SUSHI will continue, despite errors, to produce FHIR artifacts, but those artifacts may omit problematic rules. SUSHI should always exit gracefully. If SUSHI crashes, please report the issue using the [SUSHI issue tracker](https://github.com/FHIR/sushi/issues).
 
 Here are some general tips on approaching debugging:
 
 * Eliminate parsing (syntax) errors first. Messages include `extraneous input {x} expecting {y}`, `mismatched input {x} expecting {y}` and `no viable alternative at {x}`. These messages indicate that the line in question is not a valid FSH statement.
 * The order of keywords is not arbitrary. The declarations must start with the type of item you are creating (e.g., Profile, Instance, ValueSet).
 * The order of rules usually doesn't matter, but there are exceptions. Slices and extensions must be created (with `contains` rule) before they are constrained.
-* A common error is `No element found at path`. This means although the overall grammar of the statement is correct, SUSHI could not find the FHIR element you are referring to in the rule. Make sure there is no spelling error, the element names in the path are correct, and you are using the [path grammar](reference.html#paths) correctly.
+* A common error is `No element found at path`. This means that although the overall grammar of the statement is correct, SUSHI could not find the FHIR element you are referring to in the rule. Make sure there is no spelling error, the element names in the path are correct, and you are using the [path grammar](reference.html#paths) correctly.
+* If SUSHI still reports errors, but the FSH definitions appear to be correct, please report the issue using the [SUSHI issue tracker](https://github.com/FHIR/sushi/issues).
 
 ### IG Creation
 
@@ -124,7 +125,7 @@ SUSHI supports publishing implementation guides via the new template-based IG Pu
 
 #### SUSHI Inputs
 
-SUSHI uses the contents of a user-created **ig-data** directory to generate the inputs to the IG Publisher. Currently, you must create and populate this directory manually. If the input directory does not contain a subdirectory named **ig-data**, then only the FHIR artifacts (e.g., profiles, extensions, etc.) will be generated.
+SUSHI uses the contents of a user-created **ig-data** directory to generate the inputs to the IG Publisher. For a basic IG with no customization, simply create an empty **ig-data** folder. For a customized IG, create and populate the **ig-data** folder with custom content and configuration. To export only the FHIR artifacts (e.g., profiles, extensions, etc.) with no additional IG support files, ensure that no **ig-data** folder is present.
 
 A populated **ig-data** directory should look something like this:
 
@@ -151,6 +152,7 @@ Populate these directories as follows:
 
 * **ig.ini**: If present, the user-provided values will be merged with SUSHI-generated **ig.ini**.
 * **package-list.json**: This file should contain the version history of your IG. If present, it will be used instead of a generated **package-list.json**.
+* **ignoreWarnings.txt**: If present, this file can be used to suppress specific QA warnings and information messages during the FHIR IG publication process.
 * The **/images** subdirectory: Put anything that is not a page in the IG, such as images, spreadsheets or zip files, in the **images** subdirectory. These files will be copied into the build and can be referenced by user-provided pages or menus.
 * **menu.xml**: If present, this file will be used for the IG's main menu layout.
 * The **/pagecontent** subdirectory, put either markup (.xml) or markdown (.md) files with the narrative content of your IG:
@@ -158,6 +160,7 @@ Populate these directories as follows:
   * **N\_pagename.xml\|md**: If present, these files will be generated as individual pages in the IG. The leading integer (N) determines the order of the pages in the table of contents. These numbers are stripped and do not appear in the actual page URLs.
   * **{artifact-file-name}-intro.xml\|md**: If present, the contents of the file will be placed on the relevant page _before_ the artifact's definition.
   * **{artifact-file-name}-notes.xml\|md**: If present, the contents of the file will be placed on the relevant page _after_ the artifact's definition.
+* **input/{supported-resource-input-folder}** (not shown above): JSON files in supported resource folders (e.g., **profiles**, **extensions**, **examples**, etc.) will be be copied to the corresponding locations in the IG input and processed as additional (non-FSH) IG resources. This feature is not expected to be commonly used.
 
 Examples of **ig.ini**, **package-list.json**, **ignoreWarnings.txt** and **menu.xml** files can be found in the [sample IG project](https://github.com/FHIR/sample-ig) provided for this purpose. More general guidance can be found in [Guidance for HL7 IG Creation](https://build.fhir.org/ig/FHIR/ig-guidance/). The [mCODE Implementation Guide](https://github.com/standardhealth/fsh-mcode) has a good example of a populated **ig-data** directory.
 
@@ -221,7 +224,9 @@ After running SUSHI, change directories to the output directory, usually **/buil
 
 This will download the latest version of the HL7 FHIR IG Publisher tool into the **/build/input-cache** directory. _This step can be skipped if you already have the latest version of the IG Publisher tool in **input-cache**._
 
-> **Note:** If you are blocked by a firewall, or if for any reason `_updatePublisher` fails to execute, download the current IG Publisher jar file [here](https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar). When the file has downloaded, move it into the directory **/build/input-cache** (create the directory if necessary.)
+> **Note:** If you have never run the IG Publisher, you may need to install Jekyll first. See [Installing the IG Publisher](https://confluence.hl7.org/display/FHIR/IG+Publisher+Documentation) for details.
+
+> **Note:** If you are blocked by a firewall, or if for any reason `_updatePublisher` fails to execute, download the current IG Publisher jar file [here](https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar). When the file has downloaded, move it into the directory **/build/input-cache** (creating the directory if necessary.)
 
 Now run:
 
@@ -245,6 +250,6 @@ Here are some links to get started:
 
 * If you encounter issues with SUSHI, please report them on the [SUSHI issue tracker](https://github.com/FHIR/sushi/issues).
 
-* For up-to-date with information and latest releases of SUSHI, check the [release history and release notes](https://github.com/FHIR/sushi/releases).
+* For up-to-date information and latest releases of SUSHI, check the [release history and release notes](https://github.com/FHIR/sushi/releases).
 
 * To download the source code, and contribute to SUSHI, check out the open source project [hosted on Github](https://github.com/FHIR/sushi).

--- a/input/pagecontent/tutorial.md
+++ b/input/pagecontent/tutorial.md
@@ -1,11 +1,11 @@
-[FHIR Shorthand](https://github.com/HL7/fhir-shorthand) (FSH) is a specially-designed language for defining the content of FHIR Implementation Guides (IGs). It is simple and compact, with tools to produce Fast Healthcare Interoperability Resources (FHIR) profiles, extensions and IGs. FSH is compiled from text files to FHIR artifacts using [SUSHI](https://github.com/standardhealth/sushi). To get started using FSH, you need to install and run SUSHI using the steps below.
+[FHIR Shorthand](reference.html) (FSH) is a specially-designed language for defining the content of FHIR Implementation Guides (IGs). It is simple and compact, with tools to produce Fast Healthcare Interoperability Resources (FHIR) profiles, extensions and IGs. FSH is compiled from text files to FHIR artifacts using [SUSHI](sushi.html). To get started using FSH, you need to install and run SUSHI using the steps below.
 
 **Platform notes:**
 
 | Symbol | Explanation |
 |:----------|:------|
 | 💻 | Indicates information or command specific to Windows. A command window can be launched by typing `cmd` at the _Search Windows_ tool. |
-| 🍎 | Indicates information or command specific to OS X. The instructions assume the shell script is **bash**. As of the Mac Catalina release, the default is **zsh** and will need to be reconfigured as a default or at runtime to call bash shell. You can find out the default shell in a Mac terminal by running `echo $SHELL`.|
+| 🍎 | Indicates information or command specific to OS X. Commands can be run within the Terminal application. |
 | $ | Represents command prompt (may vary depending on platform) |
 {: .grid }
 
@@ -25,6 +25,14 @@ To install SUSHI, return to the command prompt, and issue this command:
 ```
 $ npm install -g fsh-sushi
 ```
+
+Check the installation by typing the following command:
+
+```
+$ sushi -h
+```
+
+If the command outputs instructions on using SUSHI command line interface (CLI), you're ready to run SUSHI.
 
 ### Step 3: Download Sample FSH Tank
 To start with some working examples of FSH files and a skeleton FSH tank, [download the fsh-tutorial-master.zip file](fsh-tutorial-master.zip) and unzip it into a directory of your choice. The zip file is also available from the Downloads menus, directly above.
@@ -85,17 +93,17 @@ Now run:
 
 🍎   `$ ./_genonce.sh`
 
-This will run the HL7 FHIR IG generator, which might several minutes to complete.
+This will run the HL7 FHIR IG generator, which may take several minutes to complete.
 
 After the publisher is finished, open the file **/FishExample/build/output/index.html** to see the resulting IG.
 
-Under artifacts menu, the IG contains two profiles, FishPatient and Veterinarian. However, if you look more closely, they don't yet have any differentials.
+If you click on the Artifacts Summary item in the menu, you will see that the IG contains two profiles, FishPatient and Veterinarian. If you look at each of them, you will notice that they have minimal differentials. The only way in which they differ from their base resource is that they require at least one name.
 
 ### Step 6: Setting Cardinalities in a Profile
 
 It is not widely known, but FHIR is designed to be used for veterinary medicine as well as human. For a non-human patient, we need to record the species. The Patients in this Tutorial are going to be various species of fish 🐟. 
 
-Since fish don't get legally married (although some species do pair bond) and they don't communicate in a human language, the first thing we'll do in the FishPatient profile is eliminate these elements. To do this, open the file **FishPatient.fsh** in your favorite plain-text editor, and add the following rules after `Description` line:
+Since fish don't get legally married (although some species do pair bond) and they don't communicate in a human language, the first thing we'll do in the FishPatient profile is eliminate these elements. To do this, open the file **FishPatient.fsh** in your favorite plain-text editor, and add the following rules after the last non-blank line in the file:
 
 ```
 * maritalStatus 0..0
@@ -114,18 +122,20 @@ Extensions are created using the `contains` keyword. To add a standalone species
 
 `* extension contains FishSpecies named species 0..1`
 
-> Note: You must be running SUSHI version 0.10.0 or higher for this to not generate a parsing error
+> **Note:** You must be running SUSHI version 0.10.0 or higher for this to not generate a parsing error
 
 This rule states that the `extension` array of the Patient resource will incorporate the `FishSpecies` extension with the local name `species`.
 
-To do this, add the following lines to the end of the **FishPatient.fsh** file:
+To define the `FishSpecies` extension, add the following lines to the end of the **FishPatient.fsh** file:
 
 ```
-Extension:  FishSpecies
-Id: fish-species
-Title: "Fish Species"
+Extension:   FishSpecies
+Id:          fish-species
+Title:       "Fish Species"
 Description: "The species of the fish."
 ```
+
+> **NOTE:** FSH ignores extra whitespace, so authors can choose to use whitespace for improved visual alignment, as in the extension definition above.
 
 Run SUSHI again (`$ sushi .`). The count of Extensions should now be 1.
 
@@ -138,15 +148,15 @@ The FishSpecies extension doesn't quite do its job yet, because we haven't speci
 * valueCodeableConcept from FishSpeciesValueSet (extensible)
 ```
 
-The first rule restricts the value[x] (an built-in element of every FHIR extension) to a CodeableConcept using the `only` keyword. The second binds it to a value set (yet to be defined) using the `from` keyword. The binding strength will be `extensible`.
+The first rule restricts the value[x] (a built-in element of every FHIR extension) to a CodeableConcept using the `only` keyword. The second binds it to a value set (yet to be defined) using the `from` keyword. The binding strength will be `extensible`.
 
 To define FishSpeciesValueSet, add the following lines to the same file:
 
 ```
-ValueSet:  FishSpeciesValueSet
-Title: "Fish Species Value Set"
-Id: fish-species-value-set
-Description:  "Codes describing various species of fish, taken from SNOMED-CT."
+ValueSet:    FishSpeciesValueSet
+Title:       "Fish Species Value Set"
+Id:          fish-species-value-set
+Description: "Codes describing various species of fish, taken from SNOMED-CT."
 * codes from system http://snomed.info/sct where concept is-a SCT#90580008  "Fish (organism)"
 ```
 
@@ -174,19 +184,19 @@ Using aliases has no effect on the IG; it simply makes the FSH code a bit neater
 
 ### Step 10: Create Shorty, an Instance of FishPatient
 
-Every IG should provide examples of its profiles. We should provide an example instance of FishPatient. Our patient example is Shorty. You will use the `Instance` keywords, with `InstanceOf` set to `FishPatient`.
+Every IG should provide examples of its profiles. We should provide an example instance of FishPatient. Our patient example is Shorty. Create this example instance using the `Instance` keyword, with `InstanceOf` set to `FishPatient` and `Usage` set to `Example`.
 
-Here some information about Shorty to include in the instance:
+Include the following information about Shorty in the instance:
 
 * His given (first) name is "Shorty" and his family (last) name is "Koi-Fish".
 * Shorty is a Koi fish (Cyprinus rubrofuscus), represented as SNOMED-CT code 47978005 "Carpiodes cyprinus (organism)".
+
+If you need help with this, you can reference the [Defining Instances](reference.html#defining-instances) section of the specification. If you still need help, you can peek at the FSH files in the **FishExampleComplete** directory.
 
 Run SUSHI again, and re-generate the IG.
 
 * Did it compile without errors?
 * What does the IG look like now?
-
-If you need help with this, you can reference the FSH files in the **FishExampleComplete** directory.
 
 ### Step 11: Create a Veterinarian Profile
 
@@ -196,11 +206,11 @@ Now, add constraints and/or extensions to the Veterinarian profile:
 
 * In addition, slice the `identifier` array, making a license number required. The code system is http://terminology.hl7.org/CodeSystem/v2-0203 and the code is LN, for "License number".
 
+If you need help with this, you can reference the [Fixed Value Rules](reference.html#fixed-value-rules) and [Slicing Rules](reference.html#slicing-rules) sections of the specification. If you still need help, you can peek at the FSH files in the **FishExampleComplete** directory.
+
 Run SUSHI again, and re-generate the IG.
 
 * Did it compile without errors?
 * What does the IG look like now?
-
-If you need help with this, you can reference the FSH files in the **FishExampleComplete** directory.
 
 Congratulations! You've completed the FSH tutorial. It might be time to feast on some sushi!


### PR DESCRIPTION
Minor edits to SUSHI, Tutorial, and Reference.

A few things to note:
* I removed the bits about bash vs. zsh because we don't use any commands that are different in zsh.  I tested the whole thing in zsh to confirm.
* The veterinarian profile is a little funny in that it says to use the `http://hl7.org/fhir/sid/ca-hc-npn` code system for qualifications, but:
  * IG Publisher reports errors about it.
  * According to the [Code Systems](http://hl7.org/fhir/R4/terminologies-systems.html) listing, that URL is for a different system: <img width="680" alt="image" src="https://user-images.githubusercontent.com/2278253/76484729-fdd33680-63f0-11ea-9510-e3a0ecf305cf.png">
  * But according to [this page](https://build.fhir.org/ig/HL7/UTG/CodeSystem-v3-HealthcareProviderTaxonomyHIPAA.html), it's for HealthcareProviderTaxonomyHIPAA (which would be right).  But I think that's wrong, as `ca-hc-npn` is definitely a better abbreviation for "Health Canada Natural Product Number" than "HealthcareProviderTaxonomyHIPAA".  So I think someone did a bad copy paste into the formal CodeSystem definition for HealthcareProviderTaxonomyHIPAA.
  * I think the real URL probably should be `http://terminology.hl7.org/CodeSystem/v3-HealthcareProviderTaxonomyHIPAA` (which the IG Publisher also does not recognize, but issues only "information" messages instead of "error" messages).
  * Since this is all wacky, and would also require a change to the tutorial zip (for the complete example), I left it as an exercise for you if you want to change it.
 