### PR TITLE
Suspected Typo

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1317,7 +1317,7 @@ Additional keywords are as follows:
 
 | Additional Keyword | Purpose | Data Type |
 |----------|---------|---------|
-| `Description` | Provides a human-readable description | string or Pmarkdown |
+| `Description` | Provides a human-readable description | string or markdown |
 | `Expression` | The FHIR path expression in an invariant | FHIRPath string |
 | `Id` | An identifier for an item | id |
 | `InstanceOf` | The profile or resource an instance instantiates | name or id or url |


### PR DESCRIPTION
Fixes a suspected typo that I noticed while reading the docs.  Observed in the [Defining Items section of the Language Reference](https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#defining-items).

Changes `Pmarkdown` to `markdown`.