### PR TITLE
Fixing a typo in the description of inline extensions

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -960,9 +960,9 @@ In these expressions, the names (`name`, `name1`, `name2`, etc.) are new local n
 
   ```
   * extension contains
-        ombCategory 0..5 MS
-        detailed 0..*
-        text 1..1 MS
+      ombCategory 0..5 MS and
+      detailed 0..* and 
+      text 1..1 MS
   // rules defining the inline extensions would typically follow:
   * extension[ombCategory].value[x] only Coding
   * extension[ombCategory].valueCoding from http://hl7.org/fhir/us/core/ValueSet/omb-race-category (required)


### PR DESCRIPTION
This section of the documentation was incorrectly missing the `and` and would not run correctly if people tried to copy and paste it. As someone did here https://chat.fhir.org/#narrow/stream/215610-shorthand/topic/Error.20in.20SUSHI.20with.20extensions.3F. This fixes that typo.