### PR TITLE
Add information about defining and inserting parameterized rule sets

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2046,7 +2046,7 @@ A filter is a logical statement in the form `{property} {operator} {value}`, whe
 
 ### Appendix: Formal Grammar
 
-The grammar of FSH described in [ANTLR4](https://www.antlr.org/):
+The grammar of FSH described in [ANTLR4](https://www.antlr.org/).
 
 #### Parser Grammar
 ```

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1330,6 +1330,8 @@ When providing a list of parameter values, enclose the list with parentheses `()
 
 The values given for the parameters are substituted into the rule set definition in order to create the rules that will be applied. The number of values provided must match the number of parameters specified in the rule set definition. Blank space that separates the rule set name from the start of the parameter value list is optional. Blank space on either side of a parameter value is removed before the value is applied to the rule set definition.
 
+Any FSH syntax errors that arise as a result of the value substitution are handled the same way as FSH syntax errors in the declaration of a rule set without parameters. The value substitution is performed without checking the types of the values being substituted or the semantic validity of the resulting rules. Any invalid rules resulting from inserting a parameterized rule set will be detected at the same time as invalid rules resulting from inserting a simple rule set.
+
 **Examples:**
 
 * Insert the rule set named [RuleSet2](#parameterized-rule-sets) into a profile:


### PR DESCRIPTION
Add information about parameterized rule sets. This results in changes to the following sections:
- 3.5.7 "Insert Rules" now contains two subsections: one for inserting a rule set without parameters, and one for inserting a rule set with parameters.
- 3.6.8 "Defining Rule Sets" now contains two subsections: one for defining a rule set without parameters, and one for defining a rule set with parameters.
- 3.8 "Appendix: Formal Grammar" now contains two subsections, as the formal grammar has been split into separate files for the parser and the lexer.