### PR TITLE
Tweaks to logical docs

### DIFF
--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -127,6 +127,18 @@ The keyword section is followed by a number of rules. Rules are the mechanism fo
 
 The [formal syntax of rules](reference.html#rules-for-profiles-extensions-logical-models-resources-and-instances) are given in the [FSH Language reference](reference.html). Here is a summary of some of the more important rules in FSH:
 
+* **AddElement rules** are used in logical models and resource definitions to define new elements. They specify a path, cardinality, optional flags, type(s), short definition, and optional long definition. For example:
+
+  ```
+  * email 0..* SU string "The person's email addresses" "Email addresses by which the person may be contacted." 
+  ```
+
+  ```
+  * preferredName 0..1 string or HumanName "The person's preferred name"
+      "The name by which the person prefers to be called, if not their formal name." 
+
+  ```
+
 * **Assignment rules** are used to set fixed values in instances and required patterns in profiles. For example:
 
   ```
@@ -238,18 +250,6 @@ The [formal syntax of rules](reference.html#rules-for-profiles-extensions-logica
   * recorder only Reference(Practitioner or PractitionerRole)
   ```
 
-
-* **AddElement rules** are used in logical models and resource definitions to define new elements. They specify a path, cardinality, optional flags, type(s), short definition, and optional long definition. For example:
-
-  ```
-  * email 0..* SU string "The person's email addresses" "Email addresses by which the person may be contacted." 
-  ```
-
-  ```
-  * preferredName 0..1 string or HumanName "The person's preferred name"
-      "The name by which the person prefers to be called, if not their formal name." 
-
-  ```
 * **Value set rules** are used to include or exclude codes in value sets. These rules can be defined two ways:
 
   [Extensional](https://blog.healthlanguage.com/the-difference-between-intensional-and-extensional-value-sets) rules explicitly list the codes to be included and/or excluded, for example:

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -913,7 +913,7 @@ Note the following:
 
 * An AddElement rule **at minimum** must specify an element path, cardinality, type, and short description.
 * Flags and longer definition are optional.
-* The longer definition can also be a multi-line (triple quoted) string
+* The longer definition can also be a multi-line (triple quoted) string.
 * If a longer definition is not specified, the element's definition will be set to the same text as the specified short description.
 * When multiple types are specified, the element path must end with \[x] unless all types are References.
 
@@ -2440,7 +2440,7 @@ Rules defining the resource follow immediately after the keyword section. Resour
 * Define a resource representing an emergency vehicle, using line spacing to make the definition easier to read:
 
   ```
-  Logical:        EmergencyVehicle
+  Resource:       EmergencyVehicle
   Title:          "Emergency Vehicle"
   Description:    "An emergency vehicle, such as an ambulance or fire truck."
   * identifier 0..* SU Identifier
@@ -2454,7 +2454,7 @@ Rules defining the resource follow immediately after the keyword section. Resour
       "The vehicle model"
       "The vehicle model, e.g., G4500."
   * model from EmergencyVehicleModel (extensible)
-  * year 0..1 SU positiveInteger
+  * year 0..1 SU positiveInt
       "Year of manufacture"
       "The year the vehicle was manufactured"
   * servicePeriod 0..1 Period


### PR DESCRIPTION
A few things got mixed up in the concurrent editing and merges in the logical and resources PR.  This PR fixes them.

This PR also moves the _AddElement rules_ section in the Overview back to its original location because all of the rule types are listed in alphabetical order.