### PR TITLE
Document insert rules with paths

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1842,7 +1842,7 @@ Any FSH syntax errors that arise as a result of the value substitution are handl
 {%include tu-div.html%}
 Rule sets can be inserted in the context of a path. The context is specified by giving the path prior to the insert rule:
 
-<pre><code>* &lt;element&gt; insert {RuleSet name}(value1<i>, value2, value3...</i>)
+<pre><code>* &lt;element&gt; insert {RuleSet name}<i>(value1, value2, value3...)</i>
 </code></pre>
 
 Alternately, the context can be given by indenting the insert rule under another rule that provides a path context (see [indented rules](#indented-rules)).

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1793,7 +1793,7 @@ Insert a simple rule set by using the name of the rule set:
 
 To insert a parameterized rule set, use the rule set name with a list of one or more parameter values:
 
-<pre><code>* insert {RuleSet name}(value1<i>, value2, value3...</i>)
+<pre><code>* insert {RuleSet name}<i>(value1, value2, value3...)</i>
 </code></pre>
 
 As indicated, the list of values is enclosed with parentheses `()` and separated by commas `,`. If you need to put literal `)` or `,` characters inside values, escape them with a backslash: `\)` and `\,`, respectively. White space separating values is optional, and removed before the value is applied to the rule set definition.

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -376,12 +376,6 @@ When indented rules are combined with [soft indexing](#soft-indexing) and a rule
   * obeys inv-1
     * family 1..1
   ```
-* An error, attempting to indent a rule without a path:
-
-  ```
-  * name 1..1
-    * insert ExampleRuleSet
-  ```
 
 </div>
 
@@ -924,7 +918,7 @@ The following table is a summary of the rules that may apply to profiles, extens
 | Contains (for standalone extensions) [3]| <code>* &lt;Extension&gt; contains {Extension name|id|url} named {name} {card} <i>{flags}</i></code> <br/>  <code> * &lt;Extension&gt; contains {Extension1 name|id|url} named {name1} {card1} <i>{flags1}</i> and {Extension2 name|id|url} named {name2} {card2} <i>{flags2}</i> ...</code>
 | Contains (for slicing) [3]| <code>* &lt;array&gt; contains {name} {card} <i>{flags}</i></code> <br/> <code>* &lt;array&gt; contains {name1} {card1} <i>{flags1}</i> and {name2} {card2} <i>{flags2}</i> ...</code>|
 | Flag | `* <element> {flag}` <br/> `* <element> {flag1} {flag2} ...` <br/> `* <element1> and <element2> and <element3> ... {flag1} {flag2} ...` |
-| Insert | <code>* insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> |
+| Insert | <code>* &lt;element&gt; insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> |
 | Obeys | `* obeys {Invariant id}` <br/> `* obeys {Invariant1 id} and {Invariant2 id} ...` <br/> `* <element> obeys {Invariant id}` <br/> `* <element> obeys {Invariant1 id} and {Invariant2 id} ...` |
 | Path {%include tu.html%} | `* <element>`|
 | Type | `* <element> only {datatype}` <br/> `* <element> only {datatype1} or {datatype2} or {datatype3} ...` <br/> `* <element> only Reference({ResourceType name|id|url})` <br/> `* <element> only Reference({ResourceType1 name|id|url} or {ResourceType2 name|id|url} or {ResourceType3 name|id|url} ...)`|
@@ -1739,21 +1733,25 @@ The following syntaxes can be used to assign flags:
 
 #### Insert Rules
 
-[Rule sets](#defining-rule-sets) are reusable groups of rules that are defined independently of other items. An insert rule is used to add a rule set:
+[Rule sets](#defining-rule-sets) are reusable groups of rules that are defined independently of other items. An insert rule is used to add a rule set with the following syntax:
 
 <pre><code>* insert {RuleSet name}<i>({parameters})</i>
+</code>
+<code>* &ltelement&gt insert {RuleSet name}<i>({parameters})</i>
 </code></pre>
 
-The rules in the named rule set are interpreted as if they were copied and pasted in the designated location.
+The rules in the named rule set are interpreted as if they were copied and pasted in the designated location. When an element is specified, the path of that element is prepended to the path of all rules in the rule set.
 
 Each rule in the rule set should be compatible with the item where the rule set is inserted, in the sense that all the rules defined in the rule set apply to elements actually present in the target. Implementations SHOULD check the legality of a rule set at compile time. If a particular rule from a rule set does not match an element in the target, that rule will not be applied, and an error SHOULD be emitted. It is up to implementations if other valid rules from the rule set are applied.
 
 ##### Inserting Simple (Non-Parameterized) Rule Sets
 
-Insert a simple rule set by using the name of the rule set:
+Insert a simple rule set by using the name of the rule set, and optionally specifying an element:
 
 ```
 * insert {RuleSet name}
+
+* <element> insert {Ruleset nanme}
 ```
 
 **Examples:**
@@ -1792,6 +1790,31 @@ Insert a simple rule set by using the name of the rule set:
   Profile: FranceBreastRadiologyObservationProfile
   Parent: BreastRadiologyObservationProfile
   * insert FranceObservationRuleSet
+  ```
+
+* Insert a rule set into a profile specifiying an element:
+
+  ```
+  RuleSet: NameRules
+  * family MS
+  * given MS
+
+  Profile: MyPatientProfile
+  Parent: Patient
+  * name insert NameRules
+  * deceased[x] only deceasedBoolean
+  // More profile rules
+  ```
+
+  This is equivalent to the following:
+
+  ```
+  Profile: MyPatientProfile
+  Parent: Patient
+  * name.family MS
+  * name.given MS
+  * deceased[x] only deceasedBoolean
+  // More profile rules
   ```
 
 ##### Inserting Parameterized Rule Sets

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -910,7 +910,7 @@ The following table is a summary of the rules that may apply to profiles, extens
 
 | Rule Type | Syntax |
 | --- | --- |
-| AddElement [1] {%include tu.html%} |`* <element> {min}..{max} {dataype} "{short}"` <br/>`* <element> {min}..{max} Reference({ResourceType name|id|url}) "{short}"` <br/>`* <element> {min}..{max} {dataype} "{short}" "{definition}"` <br/>`* <element> {min}..{max} {flag1} {flag2} ... {dataype1} or {datatype2} ... "{short}" "{definition}"` |
+| {%include tu.html%} AddElement [1]  |`* <element> {min}..{max} {dataype} "{short}"` <br/>`* <element> {min}..{max} Reference({ResourceType name|id|url}) "{short}"` <br/>`* <element> {min}..{max} {dataype} "{short}" "{definition}"` <br/>`* <element> {min}..{max} {flag1} {flag2} ... {dataype1} or {datatype2} ... "{short}" "{definition}"` |
 | Assignment [2][3] |`* <element> = {value}` <br/> `* <element> = {value} (exactly)` |
 | Binding |`* <bindable> from {ValueSet name|id|url}` <br/> `* <bindable> from {ValueSet name|id|url} ({strength})`|
 | Cardinality | `* <element> {min}..{max}` <br/>`* <element> {min}..` <br/>`* <element> ..{max}` |
@@ -918,9 +918,10 @@ The following table is a summary of the rules that may apply to profiles, extens
 | Contains (for standalone extensions) [3]| <code>* &lt;Extension&gt; contains {Extension name|id|url} named {name} {card} <i>{flags}</i></code> <br/>  <code> * &lt;Extension&gt; contains {Extension1 name|id|url} named {name1} {card1} <i>{flags1}</i> and {Extension2 name|id|url} named {name2} {card2} <i>{flags2}</i> ...</code>
 | Contains (for slicing) [3]| <code>* &lt;array&gt; contains {name} {card} <i>{flags}</i></code> <br/> <code>* &lt;array&gt; contains {name1} {card1} <i>{flags1}</i> and {name2} {card2} <i>{flags2}</i> ...</code>|
 | Flag | `* <element> {flag}` <br/> `* <element> {flag1} {flag2} ...` <br/> `* <element1> and <element2> and <element3> ... {flag1} {flag2} ...` |
-| Insert | <code>* insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> <br/>  {%include tu.html%} <code>* &lt;element&gt; insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code>|
+| Insert | <code>* insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> |
+| {%include tu.html%} Insert with Path Context | <code>* &lt;element&gt; insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code>|
 | Obeys | `* obeys {Invariant id}` <br/> `* obeys {Invariant1 id} and {Invariant2 id} ...` <br/> `* <element> obeys {Invariant id}` <br/> `* <element> obeys {Invariant1 id} and {Invariant2 id} ...` |
-| Path {%include tu.html%} | `* <element>`|
+| {%include tu.html%} Path  | `* <element>`|
 | Type | `* <element> only {datatype}` <br/> `* <element> only {datatype1} or {datatype2} or {datatype3} ...` <br/> `* <element> only Reference({ResourceType name|id|url})` <br/> `* <element> only Reference({ResourceType1 name|id|url} or {ResourceType2 name|id|url} or {ResourceType3 name|id|url} ...)`|
 {: .grid }
 
@@ -1758,7 +1759,7 @@ Insert a simple rule set by using the name of the rule set:
   Profile: MyPatientProfile
   Parent: Patient
   * insert RuleSet1
-  * deceased[x] only deceasedBoolean
+  * deceased[x] only boolean
   // More profile rules
   ```
 
@@ -1770,7 +1771,7 @@ Insert a simple rule set by using the name of the rule set:
   * ^status = #draft
   * ^experimental = true
   * ^publisher = "Elbonian Medical Society"
-  * deceased[x] only deceasedBoolean
+  * deceased[x] only boolean
   // More profile rules
   ```
 
@@ -1836,18 +1837,21 @@ Any FSH syntax errors that arise as a result of the value substitution are handl
   // more rules
   ```
 
-##### Inserting Rule Sets at Elements
+##### Inserting Rule Sets with a Path Context
+
 {%include tu-div.html%}
-To insert a rule set at an element, specify the path to that element before the insert rule:
+Rule sets can be inserted in the context of a path. The context is specified by giving the path prior to the insert rule:
 
 <pre><code>* &lt;element&gt; insert {RuleSet name}(value1<i>, value2, value3...</i>)
 </code></pre>
 
-When the rule set is expanded, the path of the element is prepended to the path of all rules in the rule set.
+Alternately, the context can be given by indenting the insert rule under another rule that provides a path context (see [indented rules](#indented-rules)).
+
+When the rule set is expanded, the path of the element is pre-pended to the path of all rules in the rule set.
 
 **Examples:**
 
-* Insert a rule set into a profile specifiying an element:
+* Insert a rule set into a profile specifying an element:
 
   ```
   RuleSet: NameRules
@@ -1857,21 +1861,34 @@ When the rule set is expanded, the path of the element is prepended to the path 
   Profile: MyPatientProfile
   Parent: Patient
   * name insert NameRules
-  * deceased[x] only deceasedBoolean
+  * deceased[x] only boolean
+  // More profile rules
+  ```
+  
+  An equivalent way to write the profile is:
+
+  ```
+  Profile: MyPatientProfile
+  Parent: Patient
+  * name 
+    * insert NameRules
+  * deceased[x] only boolean
   // More profile rules
   ```
 
-  This is equivalent to the following:
+  Both of the above are equivalent to:
 
   ```
   Profile: MyPatientProfile
   Parent: Patient
   * name.family MS
   * name.given MS
-  * deceased[x] only deceasedBoolean
+  * deceased[x] only boolean
   // More profile rules
   ```
+
 </div>
+
 #### Obeys Rules
 
 [Invariants](https://www.hl7.org/fhir/R4/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath](https://www.hl7.org/fhir/R4/fhirpath.html) or [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) expressions. An invariant can apply to an instance as a whole or a single element. Multiple invariants can be applied to an instance as a whole or to a single element. The syntax for applying invariants in profiles is:
@@ -1981,7 +1998,7 @@ Following [standard profiling rules established in FHIR](https://www.hl7.org/fhi
   ```
 
 
-#### Path Rules 
+#### Path Rules
 
 {%include tu-div.html%}
 Path rules are only used to set the context for subsequent [indented rules](#indented-rules).
@@ -2007,7 +2024,7 @@ A path rule has no impact on the element it refers to. The only purpose of the p
 
 This section explains how to define items in FSH. The general pattern used to define an item in FSH is:
 
-* One declaration keyword statement
+* One declaration statement
 * A number of additional keyword statements
 * A number of rules
 
@@ -2024,19 +2041,19 @@ Extension: TreatmentIntent
 Description: "The purpose of the treatment."
 ```
 
-Declaration keywords, corresponding to the items defined by FSH, are as follows:
+Declarations, corresponding to the items defined by FSH, are as follows:
 
-| Declaration Keyword | Purpose | Data Type |
+| Declaration | Purpose | Data Type |
 |----------|---------|---------|
 | `Alias`| Declares an alias for a URL or OID | name or $name |
 | `CodeSystem` | Declares a new code system | name |
 | `Extension` | Declares a new extension | name |
 | `Instance` | Declares a new instance | id |
 | `Invariant` | Declares a new invariant | id |
-| `Logical` {%include tu.html%} | Declares a new logical model | name |
+| {%include tu.html%} `Logical` | Declares a new logical model | name |
 | `Mapping` | Declares a new mapping | id |
 | `Profile` | Declares a new profile | name |
-| `Resource` {%include tu.html%} | Declares a new resource | name |
+|  {%include tu.html%} `Resource` | Declares a new resource | name |
 | `RuleSet` | Declares a set of rules that can be reused | name |
 | `ValueSet` | Declares a new value set | name |
 {: .grid }
@@ -2060,19 +2077,19 @@ Additional keywords are as follows:
 
 > **Note:** Keywords are case-sensitive.
 
-The following table shows the relationship between declaration keywords and additional keywords.
+The following table shows the relationship between declarations and additional keywords.
 
-| Declaration \ Keyword                  | Id  | Description | Title | Parent | InstanceOf | Usage | Source | Target | Severity | XPath | Expression |
-|----------------------------------------|-----|-------------|-------|--------|------------|-------|--------|--------|----------|-------|------------|
+| Declaration   | Id  | Description | Title | Parent | InstanceOf | Usage | Source | Target | Severity | XPath | Expression |
+|-------|-----|----------|-------|--------|------------|-------|--------|--------|-----|-------|--------|
 [Alias](#defining-aliases)               |     |             |       |        |            |       |        |        |          |       |            |
 [Code System](#defining-code-systems)    |  S  |     S       |   S   |        |            |       |        |        |          |       |            |
 [Extension](#defining-extensions)        |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
 [Instance](#defining-instances)          |  x  |     S       |   S   |        |     R      |   O   |        |        |          |       |            |
 [Invariant](#defining-invariants)        |  x  |     R       |       |        |            |       |        |        |    R     |    O  |    O       |
-[Logical](#defining-logical-models)  {%include tu.html%}    |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
+{%include tu.html%} [Logical](#defining-logical-models)  |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
 [Mapping](#defining-mappings)            |  x  |     S       |   S   |        |            |       |   R    |   R    |          |       |            |
 [Profile](#defining-profiles)            |  S  |     S       |   S   |   R    |            |       |        |        |          |       |            |
-[Resource](#defining-resources)  {%include tu.html%}        |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
+{%include tu.html%}  [Resource](#defining-resources)    |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
 [Rule Set](#defining-rule-sets)          |     |             |       |        |            |       |        |        |          |       |            |
 [Value Set](#defining-value-sets)        |  S  |     S       |   S   |        |            |       |        |        |          |       |            |
 {: .grid }

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -918,7 +918,7 @@ The following table is a summary of the rules that may apply to profiles, extens
 | Contains (for standalone extensions) [3]| <code>* &lt;Extension&gt; contains {Extension name|id|url} named {name} {card} <i>{flags}</i></code> <br/>  <code> * &lt;Extension&gt; contains {Extension1 name|id|url} named {name1} {card1} <i>{flags1}</i> and {Extension2 name|id|url} named {name2} {card2} <i>{flags2}</i> ...</code>
 | Contains (for slicing) [3]| <code>* &lt;array&gt; contains {name} {card} <i>{flags}</i></code> <br/> <code>* &lt;array&gt; contains {name1} {card1} <i>{flags1}</i> and {name2} {card2} <i>{flags2}</i> ...</code>|
 | Flag | `* <element> {flag}` <br/> `* <element> {flag1} {flag2} ...` <br/> `* <element1> and <element2> and <element3> ... {flag1} {flag2} ...` |
-| Insert | <code>* &lt;element&gt; insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> |
+| Insert | <code>* insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code> <br/>  {%include tu.html%} <code>* &lt;element&gt; insert {RuleSet name}<i>({value1}, {value2}, ...)</i></code>|
 | Obeys | `* obeys {Invariant id}` <br/> `* obeys {Invariant1 id} and {Invariant2 id} ...` <br/> `* <element> obeys {Invariant id}` <br/> `* <element> obeys {Invariant1 id} and {Invariant2 id} ...` |
 | Path {%include tu.html%} | `* <element>`|
 | Type | `* <element> only {datatype}` <br/> `* <element> only {datatype1} or {datatype2} or {datatype3} ...` <br/> `* <element> only Reference({ResourceType name|id|url})` <br/> `* <element> only Reference({ResourceType1 name|id|url} or {ResourceType2 name|id|url} or {ResourceType3 name|id|url} ...)`|
@@ -1733,25 +1733,21 @@ The following syntaxes can be used to assign flags:
 
 #### Insert Rules
 
-[Rule sets](#defining-rule-sets) are reusable groups of rules that are defined independently of other items. An insert rule is used to add a rule set with the following syntax:
+[Rule sets](#defining-rule-sets) are reusable groups of rules that are defined independently of other items. An insert rule is used to add a rule set:
 
 <pre><code>* insert {RuleSet name}<i>({parameters})</i>
-</code>
-<code>* &ltelement&gt insert {RuleSet name}<i>({parameters})</i>
 </code></pre>
 
-The rules in the named rule set are interpreted as if they were copied and pasted in the designated location. When an element is specified, the path of that element is prepended to the path of all rules in the rule set.
+The rules in the named rule set are interpreted as if they were copied and pasted in the designated location.
 
 Each rule in the rule set should be compatible with the item where the rule set is inserted, in the sense that all the rules defined in the rule set apply to elements actually present in the target. Implementations SHOULD check the legality of a rule set at compile time. If a particular rule from a rule set does not match an element in the target, that rule will not be applied, and an error SHOULD be emitted. It is up to implementations if other valid rules from the rule set are applied.
 
 ##### Inserting Simple (Non-Parameterized) Rule Sets
 
-Insert a simple rule set by using the name of the rule set, and optionally specifying an element:
+Insert a simple rule set by using the name of the rule set:
 
 ```
 * insert {RuleSet name}
-
-* <element> insert {Ruleset nanme}
 ```
 
 **Examples:**
@@ -1790,31 +1786,6 @@ Insert a simple rule set by using the name of the rule set, and optionally speci
   Profile: FranceBreastRadiologyObservationProfile
   Parent: BreastRadiologyObservationProfile
   * insert FranceObservationRuleSet
-  ```
-
-* Insert a rule set into a profile specifiying an element:
-
-  ```
-  RuleSet: NameRules
-  * family MS
-  * given MS
-
-  Profile: MyPatientProfile
-  Parent: Patient
-  * name insert NameRules
-  * deceased[x] only deceasedBoolean
-  // More profile rules
-  ```
-
-  This is equivalent to the following:
-
-  ```
-  Profile: MyPatientProfile
-  Parent: Patient
-  * name.family MS
-  * name.given MS
-  * deceased[x] only deceasedBoolean
-  // More profile rules
   ```
 
 ##### Inserting Parameterized Rule Sets
@@ -1865,6 +1836,42 @@ Any FSH syntax errors that arise as a result of the value substitution are handl
   // more rules
   ```
 
+##### Inserting Rule Sets at Elements
+{%include tu-div.html%}
+To insert a rule set at an element, specify the path to that element before the insert rule:
+
+<pre><code>* &lt;element&gt; insert {RuleSet name}(value1<i>, value2, value3...</i>)
+</code></pre>
+
+When the rule set is expanded, the path of the element is prepended to the path of all rules in the rule set.
+
+**Examples:**
+
+* Insert a rule set into a profile specifiying an element:
+
+  ```
+  RuleSet: NameRules
+  * family MS
+  * given MS
+
+  Profile: MyPatientProfile
+  Parent: Patient
+  * name insert NameRules
+  * deceased[x] only deceasedBoolean
+  // More profile rules
+  ```
+
+  This is equivalent to the following:
+
+  ```
+  Profile: MyPatientProfile
+  Parent: Patient
+  * name.family MS
+  * name.given MS
+  * deceased[x] only deceasedBoolean
+  // More profile rules
+  ```
+</div>
 #### Obeys Rules
 
 [Invariants](https://www.hl7.org/fhir/R4/conformance-rules.html#constraints) are constraints that apply to one or more values in instances, expressed as [FHIRPath](https://www.hl7.org/fhir/R4/fhirpath.html) or [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) expressions. An invariant can apply to an instance as a whole or a single element. Multiple invariants can be applied to an instance as a whole or to a single element. The syntax for applying invariants in profiles is:


### PR DESCRIPTION
This adds documentation for the functionality to put a path before an insert rule, for example, something like: 
```
  RuleSet: NameRules
  * family MS
  * given MS

  Profile: MyPatientProfile
  Parent: Patient
  * name insert NameRules
  * deceased[x] only deceasedBoolean
  // More profile rules
```