### PR TITLE
Update grammar so that alias accepts SEQUENCE and CODE

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2858,7 +2858,8 @@ options { tokenVocab = FSHLexer; }
 doc:                entity* EOF;
 entity:             alias | profile | extension | invariant | instance | valueSet | codeSystem | ruleSet | paramRuleSet | mapping | logical | resource;
 
-alias:              KW_ALIAS SEQUENCE EQUAL SEQUENCE;
+// The CODE token is accepted because the lexer parses URLs with fragments (ex: https://example.org#fragment) as CODEs
+alias:              KW_ALIAS SEQUENCE EQUAL (SEQUENCE | CODE);
 
 profile:            KW_PROFILE name sdMetadata+ sdRule*;
 extension:          KW_EXTENSION name sdMetadata* sdRule*;


### PR DESCRIPTION
This updates the grammar so that it is accurate with respect to what is currently on the master branch of SUSHI. The updates were needed to fix this bug: https://github.com/FHIR/sushi/issues/872, and were made in this PR: https://github.com/FHIR/sushi/pull/880.

@markkramerus, we weren't sure how you would want to handle this. There is not yet a new version of SUSHI released that uses this grammar, but it is on the master branch and will go out in the next release.