### PR TITLE
List-Based Change Log

### DIFF
--- a/_genonce.bat
+++ b/_genonce.bat
@@ -10,7 +10,7 @@ GOTO igpublish
 
 :isonline
 ECHO We're online
-SET txoption=-tx
+SET txoption=
 
 :igpublish
 

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -216,4 +216,4 @@ start copy /y "_updatePublisher.new.bat" "_updatePublisher.bat" ^&^& del "_updat
 
 IF "%skipPrompts%"=="true" (
   PAUSE
-}
+)

--- a/input/ImplementationGuide-hl7.fhir.uv.shorthand.xml
+++ b/input/ImplementationGuide-hl7.fhir.uv.shorthand.xml
@@ -44,6 +44,11 @@
         <title value="Language Reference"/>
         <generation value="markdown"/>
       </page>
+      <page>
+        <nameUrl value="change_log.html"/>
+        <title value="Change Log"/>
+        <generation value="markdown"/>
+      </page>
     </page>
     <parameter>
       <code value="releaselabel"/>

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -3,8 +3,9 @@
   <li><a href="overview.html">Overview</a></li>
   <li><a href="reference.html">Language Reference</a></li>
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Downloads<b class="caret"> </b></a>
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">More<b class="caret"> </b></a>
     <ul class="dropdown-menu">
+      <li><a href="change_log.html">Change Log</a></li>
       <li><a href="FSHQuickReference.pdf">Quick Reference (Cheat Sheet)</a></li>
       <li><a href="full-ig.zip">Full Implementation Guide (zip file)</a></li>
     </ul>

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -1,0 +1,26 @@
+### FHIR Shorthand 2.0.0 (HL7 Mixed Normative / Trial Use Release 1)
+
+There were no substantive changes in FHIR Shorthand 2.0.0 compared to the balloted FHIR Shorthand 1.2.0 version.
+
+### FHIR Shorthand 1.2.0 (HL7 Mixed Normative / Trial Use Ballot 1)
+
+The FHIR Shorthand Mixed Normative / Trial Use Ballot (September 2021) introduced the following substantive changes as **NORMATIVE** features. These features have been thoroughly tested by the community and are not expected to change in the future.
+
+* Soft indexing for array paths ([3.4.6](reference.html#array-paths-using-soft-indexing))
+* Extended Quantity syntax ([3.3.9](reference.html#quantities))
+
+The FHIR Shorthand Mixed Normative / Trial Use Ballot (September 2021) introduced the following substantive changes as **TRIAL USE** features. Many of these features have been tested by the community, but some may undergo changes in the future.
+
+* Parameterized rule sets ([3.5.11.2](reference.html#parameterized-rule-sets), [3.6.11.2](reference.html#inserting-parameterized-rule-sets))
+* Indented rules ([3.6.1](reference.html#indented-rules))
+* Path rules ([3.6.15](reference.html#path-rules))
+* Logical models ([3.5.7](reference.html#defining-logical-models), [3.6.2](reference.html#add-element-rules))
+* Custom resources ([3.5.10](reference.html#defining-resources), [3.6.2](reference.html#add-element-rules))
+* Hierarchical code systems ([3.5.3.1](reference.html#defining-code-systems-with-hierarchical-codes))
+* Concept-specific caret rules ([3.5.3.2](reference.html#code-metadata))
+* Inserting rule sets with path context ([3.6.11.3](reference.html#indented-rules))
+* Support for integer64 and CodeableReference ([3.2.3](reference.html#fhir-version), [3.6.3.2](reference.html#assignments-with-primitive-data-types), [3.6.3.7](reference.html#assignments-with-the-codeablereference-data-type), [3.6.4](reference.html#binding-rules), [3.6.16](reference.html#type-rules))
+
+### FHIR Shorthand 1.0.0 (HL7 Standard for Trial Use Release 1)
+
+Initial Standard for Trial Use release.


### PR DESCRIPTION
This adds a list-based change log detailing the substantive changes in the spec from STU1 to Sep 2021 ballot to the Mixed Normative / TU release.

~~I considered representing the list as a table w/ rows for "Change", "Level", "Specification Links" -- but ran out of time before I had to step out.  I can try the table if you think it might be preferred.~~

Compare this with the table-based changelog PR (#131) and choose your favorite.

See it here: http://build.fhir.org/ig/HL7/fhir-shorthand/branches/changelog/change_log.html