### PR TITLE
Update package-list.json

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -3,7 +3,7 @@
     "title" : "FHIR Shorthand",
     "canonical" : "http://hl7.org/fhir/uv/shorthand",
     "introduction" : "FHIR Shorthand (FSH) is a domain-specific language (DSL) for defining the content of FHIR Implementation Guides (IG).",
-    "category" : "Technical Infrastructure",
+    "category" : "Administration",
     "list" : [
     {
       "version" : "current",
@@ -18,7 +18,7 @@
       "fhirversion": "4.0.1",
       "desc": "FHIR Shorthand, version 2.0.0",
       "path": "http://hl7.org/fhir/uv/shorthand/N1",
-      "status": "Mixed Normative/STU",
+      "status": "normative+trial-use",
       "sequence": "N1",
       "current": false
     },


### PR DESCRIPTION
Hello all,
I’m working on the normative publication of FHIR Shorthand R2 and getting an error message: 
Update C:\inetpub\wwwroot\hl7\implement\standards\FHIR\uv\shorthand for http://hl7.org/fhir/uv/shorthand
Exception in thread "main" java.lang.Error: unknown status Mixed Normative/STU
The code for status according to https://confluence.hl7.org/display/FHIR/FHIR+IG+PackageList+doco is “normative+trial-use”.

In addition, the category has somehow changed from the existing “Administration” to a self-defined “Technical Infrastructure” which is not a current category and conflicts with the existing category when running the publisher. If you want the new category you’ll have to work with Grahame after publication to add it.

Can someone make the changes and let me know?
Thanks,
Lynn
