### PR TITLE
Add contentReference elements, more ValueSet examples, insert rules with concept context

### DIFF
--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1785,6 +1785,7 @@ Authors define logical models and resources by adding new elements to their defi
 The syntax of the rules to add a new element are as follows:
 
 <pre><code>* &lt;element&gt; {min}..{max} <span class="optional">{flag(s)}</span> {datatype(s)} "{short}" <span class="optional">"{definition}"</span>
+* &lt;element&gt; {min}..{max} <span class="optional">{flag(s)}</span> contentReference {contentUrl} "{short}" <span class="optional">"{definition}"</span>
 </code></pre>
 
 where `{datatype(s)}` can be one of the following:
@@ -1793,9 +1794,13 @@ where `{datatype(s)}` can be one of the following:
 * References to one or more resources or profiles, <code>Reference({Resource/Profile1} <span class="optional">or {Resource/Profile2} or {Resource/Profile3}...</span>)</code>
 * Canonicals for one or more resources or profiles, <code>Canonical({Resource/Profile1} <span class="optional">or {Resource/Profile2} or {Resource/Profile3}...</span>)</code>
 
+and where `{contentUrl}` is a URL referencing the element whose properties will be used to define this element. This type of element definition is typically used with recursively nested elements, such as [Questionnaire.item.item](https://www.hl7.org/fhir/R4/questionnaire-definitions.html#Questionnaire.item.item). Refer to the [ElementDefinition documentation](http://hl7.org/fhir/R4/elementdefinition-definitions.html#ElementDefinition.contentReference) for more information about using `contentReference`.
+
 Note the following:
 
-* An add element rule **at minimum** must specify an element path, cardinality, type, and short description.
+* An add element rule **at minimum** must specify:
+  * an element path, cardinality, type, and short description, OR
+  * an element path, cardinality, the `contentReference` keyword, content reference URL, and short description.
 * Flags and longer definition are optional.
 * The longer definition can also be a multi-line (triple quoted) string.
 * If a longer definition is not specified, the element's definition will be set to the same text as the specified short description.
@@ -1813,6 +1818,12 @@ Note the following:
 
   ```
   * email 0..* SU string "The person's email addresses" "Email addresses by which the person may be contacted."
+  ```
+
+* Add an element defined by a `contentReference`, which receives the content rules of the referenced element:
+
+  ```
+  * email 0..* contentReference http://example.org/StructureDefinition/AnotherResource#AnotherResource.email "The person's email addresses"
   ```
 
 * Add a reference-typed element with a longer definition:
@@ -2997,7 +3008,7 @@ logical:            KW_LOGICAL name sdMetadata* lrRule*;
 resource:           KW_RESOURCE name sdMetadata* lrRule*;
 sdMetadata:         parent | id | title | description;
 sdRule:             cardRule | flagRule | valueSetRule | fixedValueRule | containsRule | onlyRule | obeysRule | caretValueRule | insertRule | pathRule;
-lrRule:             sdRule | addElementRule;
+lrRule:             sdRule | addElementRule | addCRElementRule;
 
 instance:           KW_INSTANCE name instanceMetadata* instanceRule*;
 instanceMetadata:   instanceOf | title | description | usage;
@@ -3011,10 +3022,10 @@ vsMetadata:         id | title | description;
 vsRule:             vsComponent | caretValueRule | insertRule;
 codeSystem:         KW_CODESYSTEM name csMetadata* csRule*;
 csMetadata:         id | title | description;
-csRule:             concept | codeCaretValueRule | insertRule;
+csRule:             concept | codeCaretValueRule | codeInsertRule;
 
 ruleSet:            KW_RULESET RULESET_REFERENCE ruleSetRule+;
-ruleSetRule:        sdRule | addElementRule | concept | codeCaretValueRule | vsComponent;
+ruleSetRule:        sdRule | addElementRule | addCRElementRule | concept | codeCaretValueRule | codeInsertRule | vsComponent | mappingRule;
 
 paramRuleSet:       KW_RULESET PARAM_RULESET_REFERENCE paramRuleSetContent;
 paramRuleSetContent:   STAR
@@ -3058,6 +3069,8 @@ caretValueRule:     STAR path? caretPath EQUAL value;
 codeCaretValueRule: STAR CODE* caretPath EQUAL value;
 mappingRule:        STAR path? ARROW STRING STRING? CODE?;
 insertRule:         STAR path? KW_INSERT (RULESET_REFERENCE | PARAM_RULESET_REFERENCE);
+codeInsertRule:     STAR CODE* KW_INSERT (RULESET_REFERENCE | PARAM_RULESET_REFERENCE);
+addCRElementRule:   STAR path CARD flag* KW_CONTENTREFERENCE (SEQUENCE | CODE) STRING (STRING | MULTILINE_STRING)?;
 addElementRule:     STAR path CARD flag* targetType (KW_OR targetType)* STRING (STRING | MULTILINE_STRING)?;
 pathRule:           STAR path;
 
@@ -3148,6 +3161,7 @@ KW_VSREFERENCE:     'valueset';
 KW_SYSTEM:          'system';
 KW_EXACTLY:         '(' WS* 'exactly' WS* ')';
 KW_INSERT:          'insert' -> pushMode(RULESET_OR_INSERT);
+KW_CONTENTREFERENCE:'contentReference';
 
 // SYMBOLS
 EQUAL:              '=';

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2802,6 +2802,11 @@ Alternately, the context can be given by indenting the insert rule under another
 
 When the rule set is expanded, the path of the element is prepended to the path of all rules in the rule set.
 
+When defining a Code System, rule sets can be inserted in the context of a concept. The context is specific by giving the concept (or hierarchy of concepts, for child codes) prior to the insert rule:
+
+<pre><code>* &lt;concept&gt; insert {RuleSet}<span class="optional">(value1, value2, value3...)</span>
+</code></pre>
+
 **Examples:**
 
 * Insert a rule set into a profile specifying an element:
@@ -2841,6 +2846,48 @@ When the rule set is expanded, the path of the element is prepended to the path 
   * name.given MS
   * deceased[x] only boolean
   // More profile rules
+  ```
+
+* Insert a rule set into a code system specifying a concept:
+
+  ```
+  RuleSet: DesignationRules
+  * ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
+  * ^designation[0].language = #en
+
+  CodeSystem: MyCodeSystem
+  // skip some keywords and rules
+  * #code-one "Code one"
+  * #code-one insert DesignationRules
+  * #code-one #child-code "Child code"
+  * #code-one #child-code insert DesignationRules
+  // more code system rules
+  ```
+
+  An equivalent way to write the code system is:
+
+  ```
+  CodeSystem: MyCodeSystem
+  // skip some keywords and rules
+  * #code-one "Code one"
+    * insert DesignationRules
+    * #child-code "Child code"
+      * insert DesignationRules
+  // more code system rules
+  ```
+
+  Both of the above are equivalent to:
+
+  ```
+  CodeSystem: MyCodeSystem
+  // skip some keywords and rules
+  * #code-one "Code one"
+  * #code-one ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
+  * #code-one ^designation[0].language = #en
+  * #code-one #child-code "Child code"
+  * #code-one #child-code ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
+  * #code-one #child-code ^designation[0].language = #en
+  // more code system rules
   ```
 
 </div>

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1456,7 +1456,7 @@ Value sets are defined using the declaration `ValueSet`, with RECOMMENDED keywor
 
 Codes MUST be taken from one or more terminology systems (also called code systems or vocabularies). Codes cannot be defined inside a value set. If necessary, [you can define your own code system](#defining-code-systems).
 
-The contents of a value set are defined by a set of rules. There are four types of rules to populate a value set:
+The contents of a value set are defined by a set of rules. There are four basic types of rules to populate a value set:
 
 > **Note:** In value set rules, the word `include` is OPTIONAL.
 
@@ -1469,6 +1469,49 @@ The contents of a value set are defined by a set of rules. There are four types 
 | All codes from a code system | <code>* <span class="optional">include</span> codes from system {CodeSystem}</code> | `* include codes from system http://snomed.info/sct` |
 | Filtered codes from a code system | <code>* <span class="optional">include</span> codes from system {CodeSystem} where {filter1} <span class="optional">and {filter2}...</span></code> | `* include codes from system $SCT where concept is-a #254837009` |
 {: .grid }
+
+These basic rules can be combined and extended. When using codes from a value set, the rule may refer to more than one value set. The rule may also refer to a code system and one or more value sets. When a rule refers to more than one value set, or has a code system and one or more value sets, the applicable codes are those present in _all_ listed value set(s) (and the system, if present).  To instead add all the codes in _any_ of the value set(s) or system (that is, the _union_ of the value set(s) and system), specify them in separate rules.
+
+**Examples:**
+
+* Include codes present in all listed value sets:
+
+<code>* <span class="optional">include</span> codes from valueset {ValueSet1} and {ValueSet2} <span class="optional">and {ValueSet3} ...</span></code>
+
+  ```
+  * include codes from valueset http://hl7.org/fhir/ValueSet/units-of-time
+    and http://hl7.org/fhir/ValueSet/age-units
+  ```
+
+* Include codes present in the system and all listed value sets:
+
+<code>* <span class="optional">include</span> codes from system {CodeSystem} and valueset {ValueSet1} and {ValueSet2} <span class="optional">and {ValueSet3} ...</span></code>
+
+  ```
+  * include codes from system $UCUM
+    and valueset http://hl7.org/fhir/ValueSet/units-of-time
+    and http://hl7.org/fhir/ValueSet/age-units
+  ```
+
+* Include filtered codes from a code system and all listed value sets:
+
+<code>* <span class="optional">include</span> codes from system {CodeSystem} and valueset {ValueSet1} <span class="optional">and {ValueSet2} ...</span> where {filter1} <span class="optional">and {filter2}...</span></code>
+
+  ```
+  * include codes from system $SCT
+    and valueset http://hl7.org/fhir/ValueSet/dataelement-sdcobjectclassproperty
+    where concept is-a #254837009
+  ```
+
+> **Note:** When a rule has both a system and one or more value sets, it is acceptable to list the system before or after the value sets. All value sets must still be listed together. For example, the two following rules are valid and equivalent:
+  ```
+  * include codes from system $UCUM and valueset http://hl7.org/fhir/ValueSet/units-of-time and http://hl7.org/fhir/ValueSet/age-units
+  * include codes from valueset http://hl7.org/fhir/ValueSet/units-of-time and http://hl7.org/fhir/ValueSet/age-units and system $UCUM
+  ```
+But the following rule is invalid:
+  ```
+  * include codes from valueset http://hl7.org/fhir/ValueSet/units-of-time and system $UCUM and valueset http://hl7.org/fhir/ValueSet/age-units
+  ```
 
 > **Note:** Filters are code system dependent. See [below](#filters) for further discussion.
 


### PR DESCRIPTION
Completes tasks [CIMPL-939](https://standardhealthrecord.atlassian.net/browse/CIMPL-939) and [CIMPL-940](https://standardhealthrecord.atlassian.net/browse/CIMPL-940).

When adding an element to a Logical or Resource, it can be specified with a content reference instead of types.

When defining a ValueSet, complex rules involving a system, multiple other value sets, and filters can be defined. The new examples show some of these more complex scenarios and clarify that multiple value sets on the same rule result in an intersection of the value sets being applied.

When defining a CodeSystem, insert rules can be applied with a concept context. The syntax is similar to inserting with an element path context.