### PR TITLE
Update Change Log

### DIFF
--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -1,6 +1,6 @@
 ### FHIR Shorthand 3.0.0-ballot (HL7 Mixed Normative / Trial Use Ballot 1)
 
-The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following changes as **NORMATIVE** features. These features have been thoroughly tested by the community after being introduced as trial use in FHIR Shorthand 2.0.0 and are not expected to change in the future.
+The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following changes as **NORMATIVE** features. These features have been thoroughly tested by the community after being introduced as trial use in FHIR Shorthand 2.0.0 and are expected to remain stable in the future.
 
 * Parameterized rule sets ([3.5.11.2](reference.html#parameterized-rule-sets), [3.6.11.2](reference.html#inserting-parameterized-rule-sets))
 * Indented rules ([3.6.1](reference.html#indented-rules))

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -1,3 +1,26 @@
+### FHIR Shorthand 3.0.0-ballot (HL7 Mixed Normative / Trial Use Ballot 1)
+
+The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following changes as **NORMATIVE** features. These features have been thoroughly tested by the community after being introduced as trial use in FHIR Shorthand 2.0.0 and are not expected to change in the future.
+
+* Parameterized rule sets ([3.5.11.2](reference.html#parameterized-rule-sets), [3.6.11.2](reference.html#inserting-parameterized-rule-sets))
+* Indented rules ([3.6.1](reference.html#indented-rules))
+* Path rules ([3.6.15](reference.html#path-rules))
+* Logical models ([3.5.7](reference.html#defining-logical-models), [3.6.2](reference.html#add-element-rules))
+* Custom resources ([3.5.10](reference.html#defining-resources), [3.6.2](reference.html#add-element-rules))
+* Hierarchical code systems ([3.5.3.1](reference.html#defining-code-systems-with-hierarchical-codes))
+* Concept-specific caret rules ([3.5.3.2](reference.html#code-metadata))
+* Inserting rule sets with path context ([3.6.11.3](reference.html#inserting-rule-sets-with-path-context))
+
+The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following substantive changes as **TRIAL USE** features. Many of these features have been tested by the community, but some may undergo changes in the future.
+
+* TODO - add features as they are documented
+
+Additional minor changes to the specification include the following:
+
+* Insert rules in the context of a concept ([3.6.11.3](reference.html#inserting-rule-sets-with-path-context))
+* Add element rules with content references ([3.6.2](reference.html#add-element-rules))
+* Additional explanation and examples for using `include` ([3.5.12](reference.html#defining-value-sets))
+
 ### FHIR Shorthand 2.0.0 (HL7 Mixed Normative / Trial Use Release 1)
 
 There were no substantive changes in FHIR Shorthand 2.0.0 compared to the balloted FHIR Shorthand 1.2.0 version.


### PR DESCRIPTION
This adds a new entry to the change log for the 3.0.0 ballot. A summary of the changes (to the change log lol):

- I promoted everything that was previously listed as Trial Use to Normative, except for the item for support for integer64 and CodeableReference
- I added a placeholder for the new pieces we're planning to document but aren't in the IG yet (like the RuleSet `[[ ]]` syntax)
- I looked through the commits since the last change log commit and added a few bullet points to note other things that had changed but didn't feel that they belonged in the separate Normative/Trial Use features lists.

One piece I'm not sure about is I referenced this entry as `FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot 1`, which I'm not actually sure about, but that was my best guess since there is both normative and trial use pieces. I can change it if that is not accurate