### PR TITLE
Updated Path Rule rules

### DIFF
--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -13,12 +13,13 @@ The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) int
 
 The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following substantive changes as **TRIAL USE** features. Many of these features have been tested by the community, but some may undergo changes in the future.
 
-* TODO - add features as they are documented
+* Path rules can be used to add optional fixed values and set slice order on Instances ([3.6.15](reference.html#path-rules))
 
 Additional minor changes to the specification include the following:
 
 * Insert rules in the context of a concept ([3.6.11.3](reference.html#inserting-rule-sets-with-path-context))
 * Add element rules with content references ([3.6.2](reference.html#add-element-rules))
+* Minor correction to indicate Path Rules may be used on Mappings (Table 7 in [3.5.1.3](reference.html#rule-statements))
 * Additional explanation and examples for using `include` ([3.5.12](reference.html#defining-value-sets))
 
 ### FHIR Shorthand 2.0.0 (HL7 Mixed Normative / Trial Use Release 1)

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -785,7 +785,7 @@ A number of rules may follow the keyword statements. The grammar and meaning of 
 | [Local Code](#local-code-rules)                                    |       | Y           |           |          |           |         |         |         |          | Y        |           |
 | [Mapping](#mapping-rules)                                          |       |             |           |          |           |         | Y       |         |          | Y        |           |
 | [Obeys](#obeys-rules)                                              |       |             | Y         |          |           | Y       |         | Y       | Y        | Y        |           |
-| [Path](#path-rules)                                                |       |             | Y         | Y        |           | Y       |         | Y       | Y        | Y        |           |
+| [Path](#path-rules)                                                |       |             | Y         | Y        |           | Y       | Y       | Y       | Y        | Y        |           |
 | [Type](#type-rules)                                                |       |             | Y         |          |           | A       |         | Y       | A        | Y        |           |
 {: .grid }
 
@@ -2871,13 +2871,16 @@ The referenced invariant and its properties MUST be declared somewhere within th
 
 #### Path Rules
 
-Path rules are only used to set the context for subsequent [indented rules](#indented-rules).
+Path rules are used to set the context for subsequent [indented rules](#indented-rules).
 
 ```
 * <element>
 ```
 
-A path rule has no impact on the element it refers to. The only purpose of the path rule is to set context.
+{%include tu-div.html%}
+Path rules can also be used to include optional fixed values of a path in an Instance and indicate the order for slices to appear in an Instance. Path rules have no impact on all other FSH entity types; the only purpose of the path rule on those entities is to set context.
+</div>
+
 
 **Examples:**
 
@@ -2888,6 +2891,38 @@ A path rule has no impact on the element it refers to. The only purpose of the p
     * given MS
     * family MS
   ```
+
+{%include tu-div.html%}
+* Include optional fixed values of a path in an Instance:
+
+  Given a profile where name.given is optional and has a fixed value, such as:
+
+  ```
+  * name.given = "Doe"
+  ```
+
+  an Instance of that profile can include the fixed value "Doe" by including the following path rule:
+
+  ```
+  * name.given
+  ```
+
+* Indicate the order for slices to appear in an Instance:
+
+  Given a profile that has a required "lab" slice on category, such as:
+
+  ```
+  * category contains lab 1..1
+  * category[lab] = $OBSCAT#laboratory
+  ```
+
+  an Instance of that profile can specify that the "lab" slice should come before other values on category by including the following path rule before other rules:
+
+  ```
+  * category[lab]
+  * category[+] = $EX#example
+  ```
+</div>
 
 #### Type Rules
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2878,7 +2878,7 @@ Path rules are used to set the context for subsequent [indented rules](#indented
 ```
 
 {%include tu-div.html%}
-Path rules can also be used to include optional fixed values of a path in an Instance and indicate the order for slices to appear in an Instance. Path rules have no impact on all other FSH entity types; the only purpose of the path rule on those entities is to set context.
+Path rules can also be used to indicate the order for slices to appear in an Instance and to include optional fixed values of a path in an Instance. Path rules have no impact on all other FSH entity types; the only purpose of the path rule on those entities is to set context.
 </div>
 
 
@@ -2893,20 +2893,6 @@ Path rules can also be used to include optional fixed values of a path in an Ins
   ```
 
 {%include tu-div.html%}
-* Include optional fixed values of a path in an Instance:
-
-  Given a profile where name.family is optional and has a fixed value, such as:
-
-  ```
-  * name.family = "Smith"
-  ```
-
-  an Instance of that profile can include the fixed value "Smith" by including the following path rule:
-
-  ```
-  * name.family
-  ```
-
 * Indicate the order for slices to appear in an Instance:
 
   Given a profile that has a required "lab" slice on category, such as:
@@ -2922,6 +2908,34 @@ Path rules can also be used to include optional fixed values of a path in an Ins
   * category[lab]
   * category[+] = $EX#example
   ```
+
+* Include optional fixed values of a path in an Instance:
+
+  * Given a profile where name.family is optional and has a fixed value, such as:
+
+    ```
+    * name.family = "Smith"
+    ```
+
+    an Instance of that profile can include the fixed value "Smith" by including the following path rule:
+
+    ```
+    * name.family
+    ```
+
+  * Given a profile with an optional element that has child elements with required fixed values, such as:
+
+    ```
+    * name 0..*
+    * name.family 1..1
+    * name.family = "Smith"
+    ```
+
+    an Instance of that profile can include a name with the fixed value "Smith" by including the following path rule:
+
+    ```
+    * name
+    ```
 </div>
 
 #### Type Rules

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2895,16 +2895,16 @@ Path rules can also be used to include optional fixed values of a path in an Ins
 {%include tu-div.html%}
 * Include optional fixed values of a path in an Instance:
 
-  Given a profile where name.given is optional and has a fixed value, such as:
+  Given a profile where name.family is optional and has a fixed value, such as:
 
   ```
-  * name.given = "Doe"
+  * name.family = "Smith"
   ```
 
-  an Instance of that profile can include the fixed value "Doe" by including the following path rule:
+  an Instance of that profile can include the fixed value "Smith" by including the following path rule:
 
   ```
-  * name.given
+  * name.family
   ```
 
 * Indicate the order for slices to appear in an Instance:


### PR DESCRIPTION
This PR adds documentation for the updates to Path Rules that will be introduced in SUSHI as part of [SUSHI #1252](https://github.com/FHIR/sushi/pull/1252).

It also updates Table 7 to correctly show that Mappings can have Path Rules. This is documented elsewhere in the Spec, so this is just a correction.

*Note for reviewers*: Path Rules are marked as TU in the current version of the FSH Spec (2.0). In preparation for the 3.0 version of FSH, the TU marking was removed. However, this is brand new functionality for Path Rules. Since it only applies to Instances in specific cases, I marked the _new_ uses of Path Rules as TU here. However, there can probably be an argument made to keep all of Path Rules marked as TU. Please let me know what approach you think is best and I can update accordingly. This also is probably a good question for @markkramerus to be aware of as well.