### PR TITLE
Document Invariant Rules

### DIFF
--- a/_genonce.sh
+++ b/_genonce.sh
@@ -14,6 +14,8 @@ fi
 
 echo "$txoption"
 
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8"
+
 publisher=$input_cache_path/$publisher_jar
 if test -f "$publisher"; then
 	java -jar $publisher -ig . $txoption $*

--- a/input/includes/tu-span.html
+++ b/input/includes/tu-span.html
@@ -1,0 +1,1 @@
+<span style="background-color: #fff5e6;"><a style="padding-left: 3px; padding-right: 3px; border: 1px grey solid; font-weight: bold; color: black; background-color: #fff5e6" href="https://hl7.org/fhir/versions.html#std-process" title="Standards Status = Trial Use">TU</a>

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -13,6 +13,7 @@ The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) int
 
 The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following substantive changes as **TRIAL USE** features. Many of these features have been tested by the community, but some may undergo changes in the future.
 
+* Specifying Extension context using the Context keyword ([3.5.4](reference.html#defining-extensions))
 * Using rules in Invariant definitions ([3.5.6](reference.html#defining-invariants))
 * Inserting parameterized rule sets with values in double square brackets ([3.6.11.2](reference.html#inserting-parameterized-rule-sets))
 * Path rules can be used to add optional fixed values and set slice order on Instances ([3.6.15](reference.html#path-rules))

--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -13,6 +13,7 @@ The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) int
 
 The FHIR Shorthand 3.0.0 Mixed Normative / Trial Use Ballot (September 2023) introduced the following substantive changes as **TRIAL USE** features. Many of these features have been tested by the community, but some may undergo changes in the future.
 
+* Using rules in Invariant definitions ([3.5.6](reference.html#defining-invariants))
 * Inserting parameterized rule sets with values in double square brackets ([3.6.11.2](reference.html#inserting-parameterized-rule-sets))
 * Path rules can be used to add optional fixed values and set slice order on Instances ([3.6.15](reference.html#path-rules))
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -84,7 +84,7 @@ The following tables contain additional examples of angle brackets and curly bra
 | `{Extension}` |  The name, id, or canonical URL (or alias) of an Extension | `duration` <br/> `allergyintolerance-duration` <br/> `http://hl7.org/fhir/StructureDefinition/allergyintolerance-duration` |
 | `{flag}`  | One of the [FSH flags](#flag-rules) |  `MS` |
 | `{flag(s)}` | One or more flags, separated by whitespace | `MS SU ?!` |
-| `{Invariant}` | The id of an Invariant | `us-core-8` |
+| `{Invariant}` | The id of an Invariant | `us-core-6` |
 | `{Resource}` | The name, id, or canonical URL (or alias) of any Resource defined in the project's FHIR version | `Condition` |
 | `{Resource/Profile}` | The name, id, or canonical URL (or alias) of any Resource or Profile | `Condition` <br/> `http://hl7.org/fhir/us/core/StructureDefinition/us-core-location` |
 | `{RuleSet}` | The name of a RuleSet | `MyRuleSet` |
@@ -756,22 +756,24 @@ Depending on the type of item being defined, keywords may be required, suggested
 
 <span class="caption" id="t6">Table 6. Relationships between declarations and keywords in FSH</span>
 
-|         Keyword →<br/>Declaration ↓ | Id | Description | Title | Parent | InstanceOf | Usage | Source | Target | Severity | XPath | Expression |
-|----------------------------------------|-----|-------------|-------|--------|------------|-------|--------|--------|----------|-------|------------|
-[Alias](#defining-aliases)               |     |             |       |        |            |       |        |        |          |       |            |
-[Code System](#defining-code-systems)    |  S  |     S       |   S   |        |            |       |        |        |          |       |            |
-[Extension](#defining-extensions)        |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
-[Instance](#defining-instances)          |     |     S       |   S   |        |     R      |   O   |        |        |          |       |            |
-[Invariant](#defining-invariants)        |     |     R       |       |        |            |       |        |        |    R     |    O  |    O       |
-[Logical](#defining-logical-models)      |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
-[Mapping](#defining-mappings)            |  S  |     S       |   S   |        |            |       |   R    |   R    |          |       |            |
-[Profile](#defining-profiles)            |  S  |     S       |   S   |   R    |            |       |        |        |          |       |            |
-[Resource](#defining-resources)          |  S  |     S       |   S   |   O    |            |       |        |        |          |       |            |
-[Rule Set](#defining-rule-sets)          |     |             |       |        |            |       |        |        |          |       |            |
-[Value Set](#defining-value-sets)        |  S  |     S       |   S   |        |            |       |        |        |          |       |            |
+|            Keyword →<br/>Declaration ↓ | Id  | Description   | Title | Parent | InstanceOf | Usage | Source | Target | Severity      | Expression | XPath |
+|----------------------------------------|-----|---------------|-------|--------|------------|-------|--------|--------|---------------|------------|-------|
+[Alias](#defining-aliases)               |     |               |       |        |            |       |        |        |               |            |       |
+[Code System](#defining-code-systems)    |  S  |     S         |   S   |        |            |       |        |        |               |            |       |
+[Extension](#defining-extensions)        |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
+[Instance](#defining-instances)          |     |     S         |   S   |        |     R      |   O   |        |        |               |            |       |
+[Invariant](#defining-invariants)        |     | O<sup>*</sup> |       |        |            |       |        |        | O<sup>*</sup> |     O      |   O   |
+[Logical](#defining-logical-models)      |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
+[Mapping](#defining-mappings)            |  S  |     S         |   S   |        |            |       |   R    |   R    |               |            |       |
+[Profile](#defining-profiles)            |  S  |     S         |   S   |   R    |            |       |        |        |               |            |       |
+[Resource](#defining-resources)          |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
+[Rule Set](#defining-rule-sets)          |     |               |       |        |            |       |        |        |               |            |       |
+[Value Set](#defining-value-sets)        |  S  |     S         |   S   |        |            |       |        |        |               |            |       |
 {: .grid }
 
 **KEY:**  R = required, S = suggested (SHOULD be used), O = optional, blank = prohibited
+
+{%include tu-span.html%} <sup>*</sup>If not specified, a corresponding assignment rule (for `human` or `severity`) must specify the value instead.</span>
 
 ##### Rule Statements
 
@@ -780,23 +782,23 @@ A number of rules may follow the keyword statements. The grammar and meaning of 
 <span class="caption" id="t7">Table 7. Relationships between FSH items and FSH rules</span>
 
 |              Item →<br/>Rule Type ↓ | [Alias](#defining-aliases) | [Code System](#defining-code-systems) | [Extension](#defining-extensions) | [Instance](#defining-instances) | [Invariant](#defining-invariants) | [Logical](#defining-logical-models) | [Mapping](#defining-mappings) | [Profile](#defining-profiles) | [Resource](#defining-resources) | [Rule Set](#defining-rule-sets) | [Value Set](#defining-value-sets) |
-|--------------------------------------------------------------------|-------|-------------|-----------|----------|-----------|---------|---------|---------|----------|----------|-----------|
-| [Add Element](#add-element-rules)                                  |       |             |           |          |           | Y       |         |         | Y        | Y        |           |
-| [Assignment](#assignment-rules)                                    |       | C           | Y         | Y        |           | C       |         | Y       | C        | Y        | C         |
-| [Binding](#binding-rules)                                          |       |             | Y         |          |           | A       |         | Y       | A        | Y        |           |
-| [Cardinality](#cardinality-rules)                                  |       |             | Y         |          |           | A       |         | Y       | A        | Y        |           |
-| [Contains (inline extensions)](#contains-rules-for-extensions)     |       |             | Y         |          |           |         |         |         |          | Y        |           |
-| [Contains (standalone extensions)](#contains-rules-for-extensions) |       |             | Y         |          |           |         |         | Y       |          | Y        |           |
-| [Contains (slicing)](#contains-rules-for-slicing)                  |       |             | Y         |          |           |         |         | Y       |          | Y        |           |
-| [Exclude](#exclude-rules)                                          |       |             |           |          |           |         |         |         |          | Y        | Y         |
-| [Flag](#flag-rules)                                                |       |             | Y         |          |           | L       |         | Y       | L        | Y        |           |
-| [Include](#include-rules)                                          |       |             |           |          |           |         |         |         |          | Y        | Y         |
-| [Insert](#insert-rules)                                            |       | Y           | Y         | Y        |           | Y       | Y       | Y       | Y        | Y        | Y         |
-| [Local Code](#local-code-rules)                                    |       | Y           |           |          |           |         |         |         |          | Y        |           |
-| [Mapping](#mapping-rules)                                          |       |             |           |          |           |         | Y       |         |          | Y        |           |
-| [Obeys](#obeys-rules)                                              |       |             | Y         |          |           | Y       |         | Y       | Y        | Y        |           |
-| [Path](#path-rules)                                                |       |             | Y         | Y        |           | Y       | Y       | Y       | Y        | Y        |           |
-| [Type](#type-rules)                                                |       |             | Y         |          |           | A       |         | Y       | A        | Y        |           |
+|--------------------------------------------------------------------|---|---|---|---|------------------------------------|---|---|---|---|---|---|
+| [Add Element](#add-element-rules)                                  |   |   |   |   |                                    | Y |   |   | Y | Y |   |
+| [Assignment](#assignment-rules)                                    |   | C | Y | Y | {%include tu-span.html%} Y </span> | C |   | Y | C | Y | C |
+| [Binding](#binding-rules)                                          |   |   | Y |   |                                    | A |   | Y | A | Y |   |
+| [Cardinality](#cardinality-rules)                                  |   |   | Y |   |                                    | A |   | Y | A | Y |   |
+| [Contains (inline extensions)](#contains-rules-for-extensions)     |   |   | Y |   |                                    |   |   |   |   | Y |   |
+| [Contains (standalone extensions)](#contains-rules-for-extensions) |   |   | Y |   |                                    |   |   | Y |   | Y |   |
+| [Contains (slicing)](#contains-rules-for-slicing)                  |   |   | Y |   |                                    |   |   | Y |   | Y |   |
+| [Exclude](#exclude-rules)                                          |   |   |   |   |                                    |   |   |   |   | Y | Y |
+| [Flag](#flag-rules)                                                |   |   | Y |   |                                    | L |   | Y | L | Y |   |
+| [Include](#include-rules)                                          |   |   |   |   |                                    |   |   |   |   | Y | Y |
+| [Insert](#insert-rules)                                            |   | Y | Y | Y | {%include tu-span.html%} Y </span> | Y | Y | Y | Y | Y | Y |
+| [Local Code](#local-code-rules)                                    |   | Y |   |   |                                    |   |   |   |   | Y |   |
+| [Mapping](#mapping-rules)                                          |   |   |   |   |                                    |   | Y |   |   | Y |   |
+| [Obeys](#obeys-rules)                                              |   |   | Y |   |                                    | Y |   | Y | Y | Y |   |
+| [Path](#path-rules)                                                |   |   | Y | Y | {%include tu-span.html%} Y </span> | Y | Y | Y | Y | Y |   |
+| [Type](#type-rules)                                                |   |   | Y |   |                                    | A |   | Y | A | Y |   |
 {: .grid }
 
 **KEY:** Y = Rule type MAY be used, L = All flags except must support (MS) are supported, C = Assignments apply only to [caret paths](#caret-paths), A = Rules can only be applied to elements defined by the item (not inherited elements), blank = prohibited.
@@ -1126,30 +1128,48 @@ These conformance resources are created using FSH instance grammar. For example,
 
 #### Defining Invariants
 
-Invariants are defined using the declaration `Invariant`, with REQUIRED keywords `Description` and `Severity`, and OPTIONAL keywords `XPath` and  `Expression`. The keywords correspond directly to elements in ElementDefinition.constraint. An invariant definition cannot have rules. Invariants are incorporated into profiles, extensions, logical models, or resources via [obeys rules](#obeys-rules).
+Invariants are defined using the declaration `Invariant` and OPTIONAL keywords `Description`<sup>*</sup>, `Severity`<sup>*</sup>, `XPath` and  `Expression`. The keywords correspond directly to elements in ElementDefinition.constraint. Invariants are incorporated into profiles, extensions, logical models, or resources via [obeys rules](#obeys-rules).
 
 <span class="caption" id="t8">Table 8. Keywords used to define Invariants</span>
 
-| Keyword | Usage | Corresponding element in ElementDefinition | Data Type | Required |
-|-------|------------|--------------|-------|----|
-| Invariant | Identifier for the invariant | constraint.key | id | yes |
-| Description | Human description of constraint | constraint.human | string  | yes |
-| Expression | FHIRPath expression of constraint | constraint.expression | FHIRPath string | no |
-| Severity | Either #error or #warning, as defined in [ConstraintSeverity](https://www.hl7.org/fhir/R4/valueset-constraint-severity.html) | constraint.severity | code | yes |
-| XPath | XPath expression of constraint | constraint.xpath | XPath string | no |
+| Keyword | Usage | Corresponding element in <br/> ElementDefinition.constraint | Data Type | Required |
+|-------------|-----------------------------------|------------|-----------------|----------------|
+| Invariant   | Identifier for the invariant      | key        | id              | yes            |
+| Description | Human description of constraint   | human      | string          | no<sup>*</sup> |
+| Expression  | FHIRPath expression of constraint | expression | FHIRPath string | no             |
+| Severity    | Either #error or #warning, as defined in [ConstraintSeverity](https://www.hl7.org/fhir/R4/valueset-constraint-severity.html) | severity | code | no<sup>*</sup> |
+| XPath       | XPath expression of constraint    | xpath      | XPath string    | no             |
 {: .grid }
+
+{%include tu-div.html%}
+Authors may also specify ElementDefinition.constraint elements via [assignment rules](#assignment-rules). This approach is particularly useful for specifying constraint extensions such as the [Best Practice](https://hl7.org/fhir/extensions/StructureDefinition-elementdefinition-bestpractice.html) extension. Invariant definitions also allow [path rules](#path-rules) and [insert rules](#insert-rules).
+
+<sup>*</sup>If the `Description` keyword is not specified, then the definition must contain an assignment rule for the `human` element. If the `Severity` keyword is not specified, then the definition must contain an assignment rule for the `severity` element.
+</div>
 
 **Example:**
 
-* Define an invariant found in US Core using FSH:
+* Define a simplified version of an invariant found in US Core using FSH Invariant keywords only:
 
   ```
-  Invariant:   us-core-8
+  Invariant:   us-core-6
   Description: "Patient.name.given or Patient.name.family or both SHALL be present"
-  Expression:  "family.exists() or given.exists()"
   Severity:    #error
+  Expression:  "family.exists() or given.exists()"
   XPath:       "f:given or f:family"
   ```
+
+{%include tu-div.html%}
+* Define a simplified version of an invariant found in US Core using FSH Invariant keywords and rules:
+
+  ```
+  Invariant:   us-core-6
+  Description: "Patient.name.given or Patient.name.family or both SHALL be present"
+  * severity = #error
+  * expression = "family.exists() or given.exists()"
+  * xpath = "f:given or f:family"
+  ```
+</div>
 
 #### Defining Logical Models
 
@@ -1875,7 +1895,7 @@ The left side of this expression follows the [FSH path grammar](#fsh-paths). The
 
 Assignment rules have two very different interpretations, depending on context:
 
-* In instances, assignment rules set the **value** of the target element. Note that whenever an element is accessed via a [caret path](#caret-paths), it is actually accessing the definitional instance (for example, the StructureDefinition of the profile). Therefore, assignments involving caret paths also set the **value** of the target element.
+* In instances {%include tu-span.html%} and invariants</span>, assignment rules set the **value** of the target element. Note that whenever an element is accessed via a [caret path](#caret-paths), it is actually accessing the definitional instance (for example, the StructureDefinition of the profile). Therefore, assignments involving caret paths also set the **value** of the target element.
 * Assignment rules in profiles and extensions establish **constraints** on instances conforming to the profile or extension. The requirement is expressed as a pattern of values that must be present in the instance. In this context, an assignment rule does not set the value of the element, but instead, establishes a **constraint** on that value.
 
 This is best illustrated by example. Consider the following assignment (assuming code is a CodeableConcept):
@@ -2243,7 +2263,7 @@ Binding is the process of associating a coded element with a set of possible val
 
 <pre><code>* &lt;bindable&gt; from {ValueSet} <span class="optional">({strength})</span></code></pre>
 
-The bindable types in FHIR are [code, Coding, CodeableConcept, Quantity, string, and uri](http://hl7.org/fhir/R4/terminologies.html#4.1). In FHIR R5, <span style="background-color: #fff5e6;">{%include tu.html%} CodeableReference</span> is also bindable.
+The bindable types in FHIR are [code, Coding, CodeableConcept, Quantity, string, and uri](http://hl7.org/fhir/R4/terminologies.html#4.1). In FHIR R5, {%include tu-span.html%} CodeableReference</span> is also bindable.
 
 The strengths are the same as the [binding strengths defined in FHIR](https://www.hl7.org/fhir/R4/valueset-binding-strength.html), namely: example, preferred, extensible, and required. If strength is not specified, a required binding is assumed.
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -1089,7 +1089,7 @@ Specifying multiple contexts as a comma-separated list:
 
   ```
   Alias: $COMBINATION = http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination
-
+  
   Extension: MyExtension
   Context: $COMBINATION#extension[required]
   ```
@@ -1098,7 +1098,7 @@ Specifying multiple contexts as a comma-separated list:
 
   ```
   Alias: $COMBINATION = http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination
-
+  
   Extension: MyExtension
   Context: $COMBINATION#extension[required], $COMBINATION#extension[optional], "(Condition | Observation).code"
   ```

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -737,6 +737,7 @@ The following keywords (case-sensitive) are defined:
 
 | Keyword | Purpose | Data Type |
 |----------|---------|---------|
+| Context {%include tu.html%} | Specifies context for extensions | FHIRPath strings and element paths |
 | Description | Provides a human-readable description | string or markdown |
 | Expression | Provides a FHIR path expression in an invariant | FHIRPath string |
 | Id | Provides an identifier for an item | id |
@@ -756,19 +757,19 @@ Depending on the type of item being defined, keywords may be required, suggested
 
 <span class="caption" id="t6">Table 6. Relationships between declarations and keywords in FSH</span>
 
-|            Keyword →<br/>Declaration ↓ | Id  | Description   | Title | Parent | InstanceOf | Usage | Source | Target | Severity      | Expression | XPath |
-|----------------------------------------|-----|---------------|-------|--------|------------|-------|--------|--------|---------------|------------|-------|
-[Alias](#defining-aliases)               |     |               |       |        |            |       |        |        |               |            |       |
-[Code System](#defining-code-systems)    |  S  |     S         |   S   |        |            |       |        |        |               |            |       |
-[Extension](#defining-extensions)        |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
-[Instance](#defining-instances)          |     |     S         |   S   |        |     R      |   O   |        |        |               |            |       |
-[Invariant](#defining-invariants)        |     | O<sup>*</sup> |       |        |            |       |        |        | O<sup>*</sup> |     O      |   O   |
-[Logical](#defining-logical-models)      |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
-[Mapping](#defining-mappings)            |  S  |     S         |   S   |        |            |       |   R    |   R    |               |            |       |
-[Profile](#defining-profiles)            |  S  |     S         |   S   |   R    |            |       |        |        |               |            |       |
-[Resource](#defining-resources)          |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |
-[Rule Set](#defining-rule-sets)          |     |               |       |        |            |       |        |        |               |            |       |
-[Value Set](#defining-value-sets)        |  S  |     S         |   S   |        |            |       |        |        |               |            |       |
+|            Keyword →<br/>Declaration ↓ | Id  | Description   | Title | Parent | InstanceOf | Usage | Source | Target | Severity      | Expression | XPath | Context {%include tu.html%}|
+|----------------------------------------|-----|---------------|-------|--------|------------|-------|--------|--------|---------------|------------|-------|---------|
+[Alias](#defining-aliases)               |     |               |       |        |            |       |        |        |               |            |       |         |
+[Code System](#defining-code-systems)    |  S  |     S         |   S   |        |            |       |        |        |               |            |       |         |
+[Extension](#defining-extensions)        |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |    S    |
+[Instance](#defining-instances)          |     |     S         |   S   |        |     R      |   O   |        |        |               |            |       |         |
+[Invariant](#defining-invariants)        |     | S<sup>*</sup> |       |        |            |       |        |        | O<sup>*</sup> |     O      |   O   |         |
+[Logical](#defining-logical-models)      |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |         |
+[Mapping](#defining-mappings)            |  S  |     S         |   S   |        |            |       |   R    |   R    |               |            |       |         |
+[Profile](#defining-profiles)            |  S  |     S         |   S   |   R    |            |       |        |        |               |            |       |         |
+[Resource](#defining-resources)          |  S  |     S         |   S   |   O    |            |       |        |        |               |            |       |         |
+[Rule Set](#defining-rule-sets)          |     |               |       |        |            |       |        |        |               |            |       |         |
+[Value Set](#defining-value-sets)        |  S  |     S         |   S   |        |            |       |        |        |               |            |       |         |
 {: .grid }
 
 **KEY:**  R = required, S = suggested (SHOULD be used), O = optional, blank = prohibited
@@ -963,6 +964,7 @@ Rules types that apply to Extensions are: [Assignment](#assignment-rules), [Bind
   Id:   us-core-birthsex
   Title:  "US Core Birth Sex Extension"
   Description: "A code classifying the person's sex assigned at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9)."
+  Context: Patient
   // publisher, contact, and other metadata could be defined here using caret syntax (omitted)
   * value[x] only code
   * valueCode from http://hl7.org/fhir/us/core/ValueSet/birthsex (required)
@@ -975,6 +977,7 @@ Rules types that apply to Extensions are: [Assignment](#assignment-rules), [Bind
   Id:             us-core-ethnicity
   Title:          "US Core Ethnicity Extension"
   Description:    "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality. The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino."
+  Context: Patient, RelatedPerson, Person, Practitioner, FamilyMemberHistory
   // publisher, contact, and other metadata could be defined here using caret syntax (omitted)
   * extension contains
       ombCategory 0..1 MS and
@@ -1000,6 +1003,107 @@ Rules types that apply to Extensions are: [Assignment](#assignment-rules), [Bind
   Description:    "As of 2019, certain US states only allow M or F on birth certificates."
   * valueCode from BinaryBirthSexValueSet (required)
   ```
+
+{%include tu-div.html%}
+The keyword `Context` can be used to specify the [context](http://hl7.org/fhir/defining-extensions.html#context) of an Extension. When specifying a `fhirpath` context, the value MUST be a quoted string . When specifying an `element` or `extension` context, the value MUST start with the name, id, or URL of the context item. A name or id MAY be followed by a dot (`.`) and a valid [FSH path](#fsh-paths). A URL MAY be followed by a hash sign (`#`) and a valid [FSH path](#fsh-paths).
+
+Multiple contexts can be specified by using a comma-separated list. Using the `Context` keyword instead of using rules to assign directly to the `context` list on the Extension is recommended. The following is a list of allowed formats for contexts:
+
+Specifying a `fhirpath` context:
+  <pre><code>Context: "{fhirpath expression}"</code></pre>
+
+Specifying an `element` or `extension` context using a StructureDefinition's name or id:
+  <pre><code>Context: {StructureDefinition name or id}<span class="optional">.{FSH path}</span></code></pre>
+
+Specifying an `element` or `extension` context for using a StructureDefinition's URL:
+  <pre><code>Context: {StructureDefinition url}<span class="optional">#{FSH path}</span></code></pre>
+An alias may be used in place of the URL.
+
+Specifying multiple contexts as a comma-separated list:
+  <pre><code>Context: {context 1}<span class="optional">, {context 2}, {context 3}...</span></code></pre>
+
+**Examples:**
+
+* Defining an extension with a `fhirpath` context
+
+  ```
+  Extension: MyExtension
+  Context: "(Condition | Observation).code"
+  ```
+
+* Defining an extension with an `element` context on a core FHIR resource
+
+  ```
+  Extension: MyExtension
+  Context: Patient.contact.telecom
+  ```
+
+* Defining an extension with an `element` context on a Profile defined in FSH
+
+  ```
+  Profile: MyPatient
+  Parent: Patient
+  // rules on the Profile omitted
+
+  Extension: MyExtension
+  Context: MyPatient.contact.telecom
+  ```
+
+* Defining an extension with an `element` context that references an element whose path includes a slice. Note that the path uses square brackets to refer to a slice.
+
+  ```
+  Extension: MyExtension
+  Context: USCoreCarePlanProfile.category[AssessPlan].coding
+  // You can also use the id or the URL
+  // Context: us-core-careplan.category[AssessPlan].coding
+  // Context: http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan#category[AssessPlan].coding
+  ```
+
+* Defining an extension with an `extension` context
+
+  ```
+  Extension: MyExtension
+  Context: http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination
+  // The extension could also be referenced by name or id:
+  // Context: CSSearchParameterCombination
+  // Context: capabilitystatement-search-parameter-combination
+  ```
+
+* Defining an extension with an `extension` context that is part of a complex extension, referencing the extension by name or id
+
+  ```
+  Extension: MyExtension
+  Context: CSSearchParameterCombination.extension[required]
+  // Using the id also works:
+  // Context: capabilitystatement-search-parameter-combination.extension[required]
+  ```
+
+* Defining an extension with an `extension` context that is part of a complex extension, referencing the extension by url
+
+  ```
+  Extension: MyExtension
+  Context: http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination#extension[required]
+  ```
+
+* Defining an extension with an `extension` context by using an alias:
+
+  ```
+  Alias: $COMBINATION = http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination
+
+  Extension: MyExtension
+  Context: $COMBINATION#extension[required]
+  ```
+
+* Defining multiple contexts and using an alias:
+
+  ```
+  Alias: $COMBINATION = http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination
+
+  Extension: MyExtension
+  Context: $COMBINATION#extension[required], $COMBINATION#extension[optional], "(Condition | Observation).code"
+  ```
+
+</div>
 
 #### Defining Instances
 


### PR DESCRIPTION
This updates the spec documentation to indicate that Invariant definitions now support rules. As a result of this, the `Description` and `Severity` keywords are no longer REQUIRED since you can set those values via rules. I've marked relevant sections using the TU marker and background color.

When reviewing, note changes in the following locations:
* [Table 6. Relationships between declarations and keywords in FSH](https://build.fhir.org/ig/HL7/fhir-shorthand/branches/invariant-rules/reference.html#t6)
* [Table 7. Relationships betwen FSH items and FSH rules](https://build.fhir.org/ig/HL7/fhir-shorthand/branches/invariant-rules/reference.html#t6)
* [Section 3.5.6. Defining Invariants](https://build.fhir.org/ig/HL7/fhir-shorthand/branches/invariant-rules/reference.html#defining-invariants)
* [Change Log](https://build.fhir.org/ig/HL7/fhir-shorthand/branches/invariant-rules/change_log.html#fhir-shorthand-300-ballot-hl7-mixed-normative--trial-use-ballot-1)