### PR TITLE
Use released SUSHI 3.0.0 when linking to FSH Grammar files

### DIFF
--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -7,7 +7,7 @@
     <ul class="dropdown-menu">
       <li><a href="change_log.html">Change Log</a></li>
       <li><a href="FSHQuickReference.pdf">Quick Reference (Cheat Sheet)</a></li>
-      <li><a href="https://github.com/FHIR/sushi/tree/v3.0.0-beta.2/antlr/src/main/antlr" target="_blank">FSH Grammar</a></li>
+      <li><a href="https://github.com/FHIR/sushi/tree/v3.0.0/antlr/src/main/antlr" target="_blank">FSH Grammar</a></li>
       <li><a href="full-ig.zip">Full Implementation Guide (zip file)</a></li>
     </ul>
   </li>

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -3235,6 +3235,6 @@ Following [standard profiling rules established in FHIR](https://www.hl7.org/fhi
 
 [SUSHI](https://github.com/FHIR/sushi) provides an implementation of a FSH language parser described in [ANTLR v4](https://www.antlr.org/). It includes elements of the FSH language marked as {%include tu.html%}. The entity names defined in the grammar may not correspond to those used in the language specification. If there is a conflict between the language specification and the grammar defined in this Appendix, the language specification takes precedence. This grammar implementation is provided for informational purposes and is not normative.
 
-The latest version of the parser grammar can be found [here](https://github.com/FHIR/sushi/blob/v3.0.0-beta.2/antlr/src/main/antlr/FSH.g4).
+The latest version of the parser grammar can be found [here](https://github.com/FHIR/sushi/blob/v3.0.0/antlr/src/main/antlr/FSH.g4) and [here](https://github.com/FHIR/sushi/blob/v3.0.0/antlr/src/main/antlr/MiniFSH.g4).
 
-The latest version of the lexer grammar can be found [here](https://github.com/FHIR/sushi/blob/v3.0.0-beta.2/antlr/src/main/antlr/FSHLexer.g4).
+The latest version of the lexer grammar can be found [here](https://github.com/FHIR/sushi/blob/v3.0.0/antlr/src/main/antlr/FSHLexer.g4) and [here](https://github.com/FHIR/sushi/blob/v3.0.0/antlr/src/main/antlr/MiniFSHLexer.g4).


### PR DESCRIPTION
This updates the link in the menu to the antlr folder to link to the official 3.0.0 version. I also included the new grammar and lexer files in the short grammar section on the reference page, as well as updating the existing links there. If it is confusing including two grammar files and two lexer files, I can replace them with one link to the antlr folder, which will mirror the menu item.