### PR TITLE
Update the Reserved Words section

### DIFF
--- a/input/pagecontent/change_log.md
+++ b/input/pagecontent/change_log.md
@@ -26,6 +26,7 @@ Additional minor changes to the specification include the following:
 * Add element rules with content references ([3.6.2](reference.html#add-element-rules))
 * Minor correction to indicate Path Rules may be used on Mappings (Table 7 in [3.5.1.3](reference.html#rule-statements))
 * Additional explanation and examples for using `include` ([3.5.12](reference.html#defining-value-sets))
+* Include Reference and Canonical in the reserved words list ([3.3.2](reference.html#reserved-words))
 
 ### FHIR Shorthand 2.0.0 (HL7 Mixed Normative / Trial Use Release 1)
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -135,11 +135,13 @@ If there is discrepancy between the grammar and the FSH language description, th
 
 #### Reserved Words
 
-FSH has a number of reserved words, symbols, and patterns. Reserved words and symbols with special meaning in FSH are: `contains`, `named`, `and`, `only`, `or`, `obeys`, `true`, `false`, `include`, `exclude`, `codes`, `where`, `valueset`, `system`, `from`, `insert`, `!?`, `MS`, `SU`, `N`, `TU`, `D`, `=`, `*`, `:`, `->`, `.`,`[`, `]`.
+FSH has a number of reserved words, symbols, and patterns. Reserved words and symbols with special meaning in FSH are: `contains`, `named`, `and`, `only`, `or`, `obeys`, `true`, `false`, `include`, `exclude`, `codes`, `where`, `valueset`, `system`, `from`, `insert`, `contentReference`, `!?`, `MS`, `SU`, `N`, `TU`, `D`, `=`, `*`, `:`, `->`, `.`,`[`, `]`.
 
-The following words are reserved, with or without white spaces prior to the colon: `Alias:`, `CodeSystem:`, `Extension:`, `Instance:`, `Invariant:`, `Logical:`, `Mapping:`, `Profile:`, `Resource:`, `RuleSet:`, `ValueSet:`, `Description:`, `Expression:`, `Id:`, `InstanceOf:`, `Parent:`, `Severity:`, `Source:`, `Target:`, `Title:`, `Usage:`, `XPath:`.
+The following words are reserved, with or without white spaces prior to the colon: `Alias:`, {%include tu-span.html%}`Characteristics:`</span>, `CodeSystem:`, {%include tu-span.html%}`Context:`</span>, `Extension:`, `Instance:`, `Invariant:`, `Logical:`, `Mapping:`, `Profile:`, `Resource:`, `RuleSet:`, `ValueSet:`, `Description:`, `Expression:`, `Id:`, `InstanceOf:`, `Parent:`, `Severity:`, `Source:`, `Target:`, `Title:`, `Usage:`, `XPath:`.
 
 The following words are reserved, with or without white spaces inside the parentheses: `(example)`, `(preferred)`, `(extensible)`, `(required)`, `(exactly)`.
+
+The following words are reserved when followed by an opening parenthesis `(` with or without whitespace preceeding it, a sequence of text, and then a closing parenthesis `)`: `Canonical`, {%include tu-span.html%}`CodeableReference`</span>, `Reference`.
 
 #### Whitespace
 


### PR DESCRIPTION
Adds new reserved keywords that have been added in other PRs: `Characteristics`, `Context` (both marked as TU)
Adds missing reserved words: `contentReference`
Add sentence about other types of reserved words: `Reference`, `CodeableReference` (marked as TU), `Canonical`