### PR TITLE
publication-request.json

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -1,0 +1,11 @@
+{
+  "package-id": "hl7.fhir.uv.shorthand",
+  "version": "3.0.0-ballot",
+  "path": "https://hl7.org/fhir/uv/shorthand/2023Sep",
+  "mode": "working",
+  "status": "ballot",
+  "sequence": "Release 3",
+  "desc": "The FHIR Shorthand Release 3 ballot promotes most existing trial-use features to normative, introduces new trial-use features, and provides clarifications where necessary.",
+  "changes": "change_log.html#fhir-shorthand-300-ballot-hl7-mixed-normative--trial-use-ballot-1",
+  "first": false
+}


### PR DESCRIPTION
This PR adds the required `publication-request.json` file as documented [here](https://confluence.hl7.org/display/FHIR/IG+Publication+Request+Documentation).