### PR TITLE
Pre-ballot Fixes

### DIFF
--- a/FHIR-shorthand.xml
+++ b/FHIR-shorthand.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/shorthand/2021Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shorthand" defaultVersion="2.0.0" defaultWorkgroup="fhir-i" gitUrl="https://github.com/HL7/fhir-shorthand" url="http://hl7.org/fhir/uv/shorthand">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/shorthand/2023Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-shorthand" defaultVersion="2.0.0" defaultWorkgroup="fhir-i" gitUrl="https://github.com/HL7/fhir-shorthand" url="http://hl7.org/fhir/uv/shorthand">
 <version code="current" url="http://build.fhir.org/ig/HL7/fhir-shorthand"/>
+<version code="3.0.0-ballot" url="http://hl7.org/fhir/uv/shorthand/2023Sep"/>
 <version code="2.0.0" url="http://hl7.org/fhir/uv/shorthand/N1"/>
-<version code="1.2.0" url="http://hl7.org/fhir/uv/shorthand/2021Sep"/>
+<version code="1.2.0" deprecated="true" url="http://hl7.org/fhir/uv/shorthand/2021Sep"/>
 <version code="1.0.0" url="http://hl7.org/fhir/uv/shorthand/STU1"/>
 <version code="0.12.0" deprecated="true" url="http://hl7.org/fhir/uv/shorthand/2020May"/>
 <artifactPageExtension value="-definitions"/>

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,7 +1,7 @@
 {
   "package-id": "hl7.fhir.uv.shorthand",
   "version": "3.0.0-ballot",
-  "path": "https://hl7.org/fhir/uv/shorthand/2023Sep",
+  "path": "http://hl7.org/fhir/uv/shorthand/2023Sep",
   "mode": "working",
   "status": "ballot",
   "sequence": "Release 3",


### PR DESCRIPTION
FMG has approved FSH R3 for ballot with the following contingencies:
* The path in the publication-request.json file should be http (not https).
* The JIRA spec file needs to be updated.

This PR resolves both issues. Note that the Jira Spec file also needs to be updated in the JIRA-Spec-Artifacts repo, so there is a corresponding PR for that here: https://github.com/HL7/JIRA-Spec-Artifacts/pull/778.