### PR TITLE
Fsh 3.0 Resolutions: Styling

### DIFF
--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -27,13 +27,13 @@ The complete FSH language is formally described in the [FHIR Shorthand Language 
   * ^experimental = false
   ```
 
-* **Aliases**: To improve readability, FSH allows the user to define aliases for URLs and object identifiers (OIDs). Once defined anywhere in a FSH project, the alias can be used most places a URL or OID is required or accepted. See [Defining Aliases](reference.html#defining-aliases) for details. By convention, aliases often begin with $ character, for example:
+* **Aliases**: To improve readability, FSH allows the user to define aliases for URLs and object identifiers (OIDs). Once defined anywhere in a FSH project, the alias can be used most places a URL or OID is required or accepted. See [Defining Aliases](reference.html#defining-aliases) for details. By convention, aliases often begin with `$` character, for example:
 
   ```
   Alias: $SCT = http://snomed.info/sct
   ```
 
-* **Coded Data Types**: A leading hash sign (#) (*aka* number sign, pound sign, or octothorpe) is used in FSH to denote a code taken from a formal terminology. FSH provides special grammar for expressing FHIR's coded data types (code, Coding, and CodeableConcept) that combines the code system, code, and (optionally) a display text. Here is a SNOMED-CT code in this syntax, using the previously-defined alias:
+* **Coded Data Types**: A leading hash sign (`#`) (*aka* number sign, pound sign, or octothorpe) is used in FSH to denote a code taken from a formal terminology. FSH provides special grammar for expressing FHIR's coded data types (code, Coding, and CodeableConcept) that combines the code system, code, and (optionally) a display text. Here is a SNOMED-CT code in this syntax, using the previously-defined alias:
 
   ```
   $SCT#363346000 "Malignant neoplastic disease (disorder)"

--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -222,7 +222,7 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 26  * performer only Reference(http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner)
 27  * effective[x] only dateTime or Period
 28  * value[x] only CodeableConcept
-29  * valueCodeableConcept from ConditionStatusTrendVS (required)
+29  * value[x] from ConditionStatusTrendVS (required)
 30
 31  Extension: EvidenceType
 32  Id:  mcode-evidence-type
@@ -257,9 +257,9 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 * Line 6 gives an id for this profile. The id is used to create the globally unique URL for the profile. The URL is composed of the IG’s canonical URL, the instance type (always `StructureDefinition` for profiles), and the profile’s id.
 * Line 7 is a human-readable title for the profile.
 * Line 8 is the description that will appear in the IG on the profile's page.
-* Line 9 is the start of the rule section of the profile. It uses [caret syntax](reference.html#caret-paths) to set the status attribute in the StructureDefinition produced for this profile.
+* Line 9 is the start of the rule section of the profile. It uses [caret syntax](reference.html#caret-paths) to set the `status` attribute in the StructureDefinition produced for this profile.
 * Line 10 adds an extension to the profile using the standalone extension, `EvidenceType`, gives it the local name `evidenceType`, and assigns the cardinality 0..*. _EvidenceType is defined on line 31._
-* Line 11 binds the valueCodeableConcept of the evidenceType extension to a value set named CancerDiseaseStatusEvidenceTypeVS with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
+* Line 11 binds the `valueCodeableConcept` of the evidenceType extension to a value set named CancerDiseaseStatusEvidenceTypeVS with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
 * Line 12 designates a list of elements (inherited from Observation) as must-support.
 * Lines 13 to 20 constrain the cardinality of some inherited elements. FSH does not support setting the cardinality of a multiple items at a time, so these must be separate statements.
 * Lines 21 and 22 restrict the choice of resource types for two elements that refer to other resources.
@@ -267,12 +267,12 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 * Lines 24 to 25 reduce an inherited choice of resource references down to instances that conform specific profiles (which must be defined, but are external to this example)
 * Line 26 is similar to lines 24 and 25, but the reference is to an external profile.
 * Line 27 and 28 restrict the data type for elements that offer a choice of data types in the base resource.
-* Line 29 binds the remaining allowed data type for value[x], valueCodeableConcept, to the value set ConditionStatusTrendVS with a required binding. _ConditionStatusTrendVS is defined on line 37._
+* Line 29 binds the remaining allowed data type for `value[x]`, a CodeableConcept, to the value set ConditionStatusTrendVS with a required binding. _ConditionStatusTrendVS is defined on line 37._
 * Line 31 declares an extension named EvidenceType.
 * Line 32 assigns an id to the extension.
 * Line 33 gives the extension a human-readable title.
 * Line 34 gives the extension a description that will appear on the extension's main page.
-* Line 35 begins the rule section for the extension, and restricts the data type of the value[x] element of the extension to a CodeableConcept.
+* Line 35 begins the rule section for the extension, and restricts the data type of the `value[x]` element of the extension to a CodeableConcept.
 * Line 37 declares a value set named ConditionStatusTrendVS.
 * Line 38 gives the value set an id.
 * Line 39 provides a human readable title for the value set.

--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -252,14 +252,14 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 ```
 
 * Lines 1 and 2 define aliases for the LOINC and SNOMED-CT code systems.
-* Line 4 declares the intent to create a profile with the name CancerDiseaseStatus. The name is typically PascalCase (also known as UpperCamelCase) and according to FHIR, should be "[usable by machine processing applications such as code generation](https://hl7.org/fhir/structuredefinition.html#resource)".
+* Line 4 declares the intent to create a profile with the name `CancerDiseaseStatus`. The name is typically PascalCase (also known as UpperCamelCase) and according to FHIR, should be "[usable by machine processing applications such as code generation](https://hl7.org/fhir/structuredefinition.html#resource)".
 * Line 5 says that this profile will be based on Observation.
 * Line 6 gives an id for this profile. The id is used to create the globally unique URL for the profile. The URL is composed of the IG’s canonical URL, the instance type (always `StructureDefinition` for profiles), and the profile’s id.
 * Line 7 is a human-readable title for the profile.
 * Line 8 is the description that will appear in the IG on the profile's page.
 * Line 9 is the start of the rule section of the profile. It uses [caret syntax](reference.html#caret-paths) to set the `status` attribute in the StructureDefinition produced for this profile.
 * Line 10 adds an extension to the profile using the standalone extension, `EvidenceType`, gives it the local name `evidenceType`, and assigns the cardinality 0..*. _EvidenceType is defined on line 31._
-* Line 11 binds the `valueCodeableConcept` of the `evidenceType` extension to a value set named CancerDiseaseStatusEvidenceTypeVS with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
+* Line 11 binds the `valueCodeableConcept` of the `evidenceType` extension to a value set named `CancerDiseaseStatusEvidenceTypeVS` with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
 * Line 12 designates a list of elements (inherited from Observation) as must-support.
 * Lines 13 to 20 constrain the cardinality of some inherited elements. FSH does not support setting the cardinality of a multiple items at a time, so these must be separate statements.
 * Lines 21 and 22 restrict the choice of resource types for two elements that refer to other resources.
@@ -267,18 +267,18 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 * Lines 24 to 25 reduce an inherited choice of resource references down to instances that conform specific profiles (which must be defined, but are external to this example)
 * Line 26 is similar to lines 24 and 25, but the reference is to an external profile.
 * Line 27 and 28 restrict the data type for elements that offer a choice of data types in the base resource.
-* Line 29 binds the remaining allowed data type for `value[x]`, a CodeableConcept, to the value set ConditionStatusTrendVS with a required binding. _ConditionStatusTrendVS is defined on line 37._
-* Line 31 declares an extension named EvidenceType.
+* Line 29 binds the remaining allowed data type for `value[x]`, a CodeableConcept, to the value set `ConditionStatusTrendVS` with a required binding. _ConditionStatusTrendVS is defined on line 37._
+* Line 31 declares an extension named `EvidenceType`.
 * Line 32 assigns an id to the extension.
 * Line 33 gives the extension a human-readable title.
 * Line 34 gives the extension a description that will appear on the extension's main page.
 * Line 35 begins the rule section for the extension, and restricts the data type of the `value[x]` element of the extension to a CodeableConcept.
-* Line 37 declares a value set named ConditionStatusTrendVS.
+* Line 37 declares a value set named `ConditionStatusTrendVS`.
 * Line 38 gives the value set an id.
 * Line 39 provides a human readable title for the value set.
 * Line 40 gives the value set a description that will appear on the value set's main page.
 * Lines 41 to 45 define the codes that are members of the value set.
-* Lines 47 to 55 create another value set, CancerDiseaseStatusEvidenceTypeVS, similar to the previous one.
+* Lines 47 to 55 create another value set, `CancerDiseaseStatusEvidenceTypeVS`, similar to the previous one.
 
 A few things to note about this example:
 

--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -89,7 +89,7 @@ The keyword section is followed by a number of rules. Rules are the mechanism fo
   * valueQuantity = UCUM#mm "millimeters"
   ```
 
-* **Binding rules** are used on elements with coded values to specify the set of enumerated values for that element. Binding rules include [one of FHIR's binding strengths](https://hl7.org/fhir/R5/valueset-binding-strength.html): example, preferred, extensible, or required. For example:
+* **Binding rules** are used on elements with coded values to specify the set of enumerated values for that element. Binding rules include [one of FHIR's binding strengths](https://hl7.org/fhir/R5/valueset-binding-strength.html): `example`, `preferred`, `extensible`, or `required`. For example:
 
   ```
   * gender from http://hl7.org/fhir/ValueSet/administrative-gender (required)

--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -21,7 +21,7 @@ The complete FSH language is formally described in the [FHIR Shorthand Language 
   ```
 
 * **Escape Character**: FSH uses the backslash as the escape character in string literals. For example, use `\"` to embed a quotation mark in a string.
-* **Caret Character**: FSH uses [caret syntax](reference.html#caret-paths) to directly reference the definitional structure associated with an item. When defining a profile, the caret character `^` (also called circumflex) allows you to refer to elements in the StructureDefinition. For example, to set the element StructureDefinition.experimental:
+* **Caret Character**: FSH uses [caret syntax](reference.html#caret-paths) to directly reference the definitional structure associated with an item. When defining a profile, the caret character `^` (also called circumflex) allows you to refer to elements in the StructureDefinition. For example, to set the element `StructureDefinition.experimental`:
 
   ```
   * ^experimental = false
@@ -115,7 +115,7 @@ The keyword section is followed by a number of rules. Rules are the mechanism fo
 
 * **Contains rules** are used for slicing and extensions. Both cases involve specifying the type of elements that can appear in arrays.
 
-  The following rule slices Observation.component into the two components of blood pressure:
+  The following rule slices `Observation.component` into the two components of blood pressure:
 
   ```
   * component contains systolicBP 1..1 and diastolicBP 1..1

--- a/input/pagecontent/overview.md
+++ b/input/pagecontent/overview.md
@@ -259,7 +259,7 @@ In this section, we will walk through a realistic example of FSH, line by line. 
 * Line 8 is the description that will appear in the IG on the profile's page.
 * Line 9 is the start of the rule section of the profile. It uses [caret syntax](reference.html#caret-paths) to set the `status` attribute in the StructureDefinition produced for this profile.
 * Line 10 adds an extension to the profile using the standalone extension, `EvidenceType`, gives it the local name `evidenceType`, and assigns the cardinality 0..*. _EvidenceType is defined on line 31._
-* Line 11 binds the `valueCodeableConcept` of the evidenceType extension to a value set named CancerDiseaseStatusEvidenceTypeVS with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
+* Line 11 binds the `valueCodeableConcept` of the `evidenceType` extension to a value set named CancerDiseaseStatusEvidenceTypeVS with a required binding strength. _CancerDiseaseStatusEvidenceTypeVS is defined on line 47._
 * Line 12 designates a list of elements (inherited from Observation) as must-support.
 * Lines 13 to 20 constrain the cardinality of some inherited elements. FSH does not support setting the cardinality of a multiple items at a time, so these must be separate statements.
 * Lines 21 and 22 restrict the choice of resource types for two elements that refer to other resources.

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -365,11 +365,11 @@ When processing triple-quoted strings, implementations MUST follow the approach 
 
 #### Item Names
 
-Item names SHOULD follow [FHIR naming guidance](https://hl7.org/fhir/R5/structuredefinition-definitions.html#StructureDefinition.name). All item names MUST be between 1 and 255 characters. Item names MUST begin with an uppercase ASCII letter and contain only ASCII letters, numbers, and underscores ("_"). By convention, item names SHOULD use [PascalCase (also known as UpperCamelCase)](https://wiki.c2.com/?UpperCamelCase).
+Item names SHOULD follow [FHIR naming guidance](https://hl7.org/fhir/R5/structuredefinition-definitions.html#StructureDefinition.name). All item names MUST be between 1 and 255 characters. Item names MUST begin with an uppercase ASCII letter and contain only ASCII letters, numbers, and underscores (`_`). By convention, item names SHOULD use [PascalCase (also known as UpperCamelCase)](https://wiki.c2.com/?UpperCamelCase).
 
-[Slice names](#contains-rules-for-slicing) and [local slice names for extensions](#contains-rules-for-extensions) SHOULD use [lower camelCase](https://wiki.c2.com/?CamelCase). Slice names MUST contain only ASCII letters, numbers, underscores ("_"), hyphens ("-"), at signs ("@"), and forward slashes ("/", used only for re-slicing). These conventions are consistent with FHIR slice naming conventions specified in [eld-16](https://hl7.org/fhir/R5/elementdefinition-definitions.html#def), aside from disallowing square brackets ("[" and "]") since they are used by [sliced array path](#sliced-array-paths) syntax.
+[Slice names](#contains-rules-for-slicing) and [local slice names for extensions](#contains-rules-for-extensions) SHOULD use [lower camelCase](https://wiki.c2.com/?CamelCase). Slice names MUST contain only ASCII letters, numbers, underscores (`_`), hyphens (`-`), at signs (`@`), and forward slashes (`/`, used only for re-slicing). These conventions are consistent with FHIR slice naming conventions specified in [eld-16](https://hl7.org/fhir/R5/elementdefinition-definitions.html#def), aside from disallowing square brackets (`[` and `]`) since they are used by [sliced array path](#sliced-array-paths) syntax.
 
-Alias names SHOULD begin with a dollar sign ("$") and MUST otherwise contain only ASCII letters, numbers, underscores ("_"), hyphens ("-"), and dots ("."). Beginning alias names with $ is a good practice, since this convention allows for additional error checking ([see Defining Aliases](#defining-aliases) for details).
+Alias names SHOULD begin with a dollar sign (`$`) and MUST otherwise contain only ASCII letters, numbers, underscores (`_`), hyphens (`-`), and dots (`.`). Beginning alias names with `$` is a good practice, since this convention allows for additional error checking ([see Defining Aliases](#defining-aliases) for details).
 
 > **Note:** Instances have identifiers rather than names, so instance declarations SHALL follow the recommendations for [Item Identifiers](#item-identifiers).
 
@@ -377,7 +377,7 @@ Alias names SHOULD begin with a dollar sign ("$") and MUST otherwise contain onl
 
 Item identifiers (ids) MUST be unique within the scope of its item type in the FSH project. For example, two Profiles with the same id cannot coexist, but it is possible to have a Profile and a ValueSet with the same id in the same FSH Project. However, to minimize potential confusion, it is best to use a unique id for every item in a FSH project. If no id is provided by a FSH author, implementations MAY create an id.
 
-Ids MUST contain only ASCII letters, numerals, hyphens ("-"), and dots ("."), with a length limit of 64 characters (per the requirements of the [FHIR id datatype](https://hl7.org/fhir/R5/datatypes.html#primitive)). By convention, ids SHOULD be lowercase with words separated by hyphens. If the item has a name, the id SHOULD be based on the item's name, with _ replaced by -, changed to lowercase, and truncated if necessary.
+Ids MUST contain only ASCII letters, numerals, hyphens (`-`), and dots (`.`), with a length limit of 64 characters (per the requirements of the [FHIR id datatype](https://hl7.org/fhir/R5/datatypes.html#primitive)). By convention, ids SHOULD be lowercase with words separated by hyphens. If the item has a name, the id SHOULD be based on the item's name, with `_` replaced by `-`, changed to lowercase, and truncated if necessary.
 
 #### Referring to Items
 
@@ -864,7 +864,7 @@ Several things to note about aliases:
 * Aliases SHALL only be substituted where a full uri value is expected (e.g., they cannot be placed in the middle of a string or used to construct a larger url).
 * Aliases SHALL be global within a FSH project.
 
-In contrast with other names in FSH (for profiles, extensions, etc.), alias names MAY optionally begin with a dollar sign ($). If you define an alias with a leading $, implementations can more easily check for misspellings. For example, if you choose the alias name `$RaceAndEthnicity` and accidentally type `$RaceEthnicity`, implementations can easily detect there is no alias by that name. Without the $ sign, implementations are forced to look through FHIR Core and all external implementation guides for anything with that name or id, or in some contexts, assume it is a new item, with unpredictable results.
+In contrast with other names in FSH (for profiles, extensions, etc.), alias names MAY optionally begin with a dollar sign (`$`). If you define an alias with a leading `$`, implementations can more easily check for misspellings. For example, if you choose the alias name `$RaceAndEthnicity` and accidentally type `$RaceEthnicity`, implementations can easily detect there is no alias by that name. Without the `$` sign, implementations are forced to look through FHIR Core and all external implementation guides for anything with that name or id, or in some contexts, assume it is a new item, with unpredictable results.
 
 **Examples:**
 
@@ -1078,7 +1078,7 @@ Rules types that apply to Extensions are: [Assignment](#assignment-rules), [Bind
   ```
 
 {%include tu-div.html%}
-The keyword `Context` SHOULD be used to specify the [context](https://hl7.org/fhir/R5/defining-extensions.html#context) of an Extension. When specifying a `fhirpath` context, the value MUST be a quoted string . When specifying an `element` or `extension` context, the value MUST start with the name, id, or URL of the context item. A name or id MAY be followed by a dot (`.`) and a valid [FSH path](#fsh-paths). A URL MAY be followed by a hash sign (`#`) and a valid [FSH path](#fsh-paths).
+The keyword `Context` SHOULD be used to specify the [context](https://hl7.org/fhir/R5/defining-extensions.html#context) of an Extension. When specifying a `fhirpath` context, the value MUST be a quoted string. When specifying an `element` or `extension` context, the value MUST start with the name, id, or URL of the context item. A name or id MAY be followed by a dot (`.`) and a valid [FSH path](#fsh-paths). A URL MAY be followed by a hash sign (`#`) and a valid [FSH path](#fsh-paths).
 
 Multiple contexts MAY be specified by using a comma-separated list. Using the `Context` keyword instead of using caret rules to assign directly to the `context` list on the Extension is RECOMMENDED. The following is a list of allowed formats for contexts:
 
@@ -2273,7 +2273,7 @@ A FHIR Coding has five attributes (`system`, `version`, `code`, `display`, and `
 
 <pre><code>&lt;Coding&gt; = <span class="optional">{CodeSystem}|{version string}</span>#{code} <span class="optional">"{display string}"</span></code></pre>
 
-The only REQUIRED part of this statement is the code (including the # sign), although every Coding SHOULD have a code system. The version string MUST NOT appear without a code system.
+The only REQUIRED part of this statement is the code (including the `#` sign), although every Coding SHOULD have a code system. The version string MUST NOT appear without a code system.
 
 Whenever this type of rule is applied, whatever is on the right side SHALL **entirely replace** the previous value of the Coding on the left side. For example, if a Coding has a value that includes a display string, and a subsequent assignment replaces the system and code but has no display string, the result is a Coding without a display string.
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -393,7 +393,7 @@ FSH path grammar allows you to refer to any element of a profile, extension, or 
 * Nested elements, such as the `text` element of the `method` element of an Observation
 * Elements in a list or array, such as the second element in the `name` array of a Patient resource
 * Individual datatypes of choice elements, such as `onsetAge` in `onset[x]`
-* Individual slices within a sliced array, such as the systolicBP component in a blood pressure Observation
+* Individual slices within a sliced array, such as the `systolicBP` component slice in a blood pressure Observation
 * Metadata elements of definitional resources, such as the `experimental` and `active` elements of a StructureDefinition.
 * Properties of ElementDefinitions nested within a StructureDefinition, such as the `maxLength` property of string elements
 
@@ -585,13 +585,13 @@ Since slices are sublists, a sliced array path technically points to the *first*
 
 **Examples:**
 
-* Path to the coded value of the respirationScore component within an Observation profile representing an Apgar test:
+* Path to the coded value of the `respirationScore` component slice within an Observation profile representing an Apgar test:
 
   ```
   component[respirationScore].code
   ```
 
-* Paths to the codes representing the one minute and five minute respiration scores, assuming the Apgar respiration component has been resliced:
+* Paths to the codes representing the one minute and five minute respiration scores, assuming the Apgar `respirationScore` component slice has been resliced:
 
   ```
   component[respirationScore][oneMinuteScore].code
@@ -599,7 +599,7 @@ Since slices are sublists, a sliced array path technically points to the *first*
   component[respirationScore][fiveMinuteScore].code
   ```
 
-* Paths to the MedicationRequest and NutritionOrder reference options in an "orders" slice that allows both types:
+* Paths to the MedicationRequest and NutritionOrder reference options in an `orders` slice that allows both types:
 
   ```
   basedOn[orders][MedicationRequest]
@@ -607,7 +607,7 @@ Since slices are sublists, a sliced array path technically points to the *first*
   basedOn[orders][NutritionOrder]
   ```
 
-* Paths to the resources of the second and third entries in the medications slice of a profiled Bundle:
+* Paths to the resources of the second and third entries in the `medications` slice of a profiled Bundle:
 
   ```
   entry[medications][1].resource
@@ -637,13 +637,13 @@ For locally-defined extensions, using the slice name is the simplest choice. For
 
 **Examples:**
 
-* Path to the value of the birth sex extension in US Core Patient, whose local slice name is birthsex:
+* Path to the value of the birth sex extension in US Core Patient, whose local slice name is `birthsex`:
 
   ```
   extension[birthsex].valueCode
   ```
 
-* Path to an extension on the `telecom` element of Patient, assuming the extension has been given the local slice name directMailAddress:
+* Path to an extension on the `telecom` element of Patient, assuming the extension has been given the local slice name `directMailAddress`:
 
   ```
   telecom.extension[directMailAddress]
@@ -655,7 +655,7 @@ For locally-defined extensions, using the slice name is the simplest choice. For
   telecom.extension[http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct]
   ```
 
-* Path to the Coding datatype of the `value[x]` in the nested extension ombCategory under the ethnicity extension in US Core, using the slice names of the extensions:
+* Path to the Coding datatype of the `value[x]` in the nested extension `ombCategory` under the `ethnicity` extension in US Core, using the slice names of the extensions:
 
   ```
   extension[ethnicity].extension[ombCategory].valueCoding
@@ -2910,7 +2910,7 @@ Reslicing (slicing an existing slice) uses a similar syntax, but the left-hand s
 
 **Example:**
 
-* In an Observation for Apgar score, reslice the Apgar respiration score component into one-, five-, and ten-minute scores:
+* In an Observation for Apgar score, reslice the Apgar `respirationScore` component slice into one-, five-, and ten-minute scores:
 
   ```
   * component contains
@@ -2935,7 +2935,7 @@ The slice content rules MUST appear *after* the contains rule that creates the s
 
 **Example:**
 
-* Constrain the content of the systolicBP and diastolicBP slices:
+* Constrain the content of the `systolicBP` and `diastolicBP` slices:
 
   ```
   * component[systolicBP].code = $LNC#8480-6 // Systolic blood pressure
@@ -3393,14 +3393,14 @@ Path rules MAY also be used to indicate the order for slices to appear in an Ins
 {%include tu-div.html%}
 * Indicate the order for slices to appear in an Instance:
 
-  Given a profile that has a required "lab" slice on `category`, such as:
+  Given a profile that has a required `lab` slice on `category`, such as:
 
   ```
   * category contains lab 1..1
   * category[lab] = $OBSCAT#laboratory
   ```
 
-  an Instance of that profile can specify that the "lab" slice MUST come before other values on `category` by including the following path rule before other rules:
+  an Instance of that profile can specify that the `lab` slice MUST come before other values on `category` by including the following path rule before other rules:
 
   ```
   * category[lab]

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -843,7 +843,7 @@ A number of rules usually follow the keyword statements. The grammar and meaning
 | [Type](#type-rules)                                                |   |   | Y |   |                                    | {%include tu-span.html%} Y </span> |   | Y | A | Y |   |
 {: .grid }
 
-**KEY:** Y = Rule type MAY be used, L = All flags except must support (MS) are supported, C = Assignments apply only to [caret paths](#caret-paths), A = Rules can only be applied to elements defined by the item (not inherited elements), blank = prohibited.
+**KEY:** Y = Rule type MAY be used, L = All flags except must support (`MS`) are supported, C = Assignments apply only to [caret paths](#caret-paths), A = Rules can only be applied to elements defined by the item (not inherited elements), blank = prohibited.
 
 #### Defining Aliases
 
@@ -1363,7 +1363,7 @@ Logical models allow authors to define new structures representing arbitrary con
 
 Logical models are defined using the REQUIRED declaration `Logical`, with RECOMMENDED keywords `Id`, `Title`, and `Description`, and OPTIONAL keyword `Parent`. If no `Parent` is specified, the empty [Base](https://hl7.org/fhir/R5/types.html#Base) type SHALL be assumed as the default parent. Note that the Base type does not exist in FHIR R4, but both SUSHI and the FHIR IG Publisher have implemented special case logic to support Base in FHIR R4. Authors who wish to have top-level `id` and `extension` elements MAY use [Element](https://hl7.org/fhir/R5/types.html#Element) as the logical model's parent instead (when appropriate, based on the definition of Element). Alternately, authors MAY specify another logical model, a resource, or a complex datatype as a logical model's parent. Logical model metadata that does not have a dedicated keyword MAY be specified using assignment rules with [caret paths](#caret-paths) (e.g., `^url`, `^status`, `^purpose`).
 
-Rules defining the logical model follow immediately after the keyword section. Rule types that apply to Logicals are: [Add Element](#add-element-rules), [Assignment](#assignment-rules), [Binding](#binding-rules), [Cardinality](#cardinality-rules), [Flag](#flag-rules), [Insert](#insert-rules), [Obeys](#obeys-rules), [Path](#path-rules), and [Type](#type-rules). Flag rules SHALL NOT include MS flags.
+Rules defining the logical model follow immediately after the keyword section. Rule types that apply to Logicals are: [Add Element](#add-element-rules), [Assignment](#assignment-rules), [Binding](#binding-rules), [Cardinality](#cardinality-rules), [Flag](#flag-rules), [Insert](#insert-rules), [Obeys](#obeys-rules), [Path](#path-rules), and [Type](#type-rules). Flag rules SHALL NOT include `MS` flags.
 
 In addition, authors SHOULD consult FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements listed as prohibited in that table. For example, the table indicates that assigning `maxLength` and `mustSupport` is prohibited.
 
@@ -1524,7 +1524,7 @@ Resources are defined using the REQUIRED declaration `Resource`. The keywords `I
 Rules defining the resource follow immediately after the keyword section. Rules types that apply to resources are: [Add Element](#add-element-rules), [Assignment](#assignment-rules), [Binding](#binding-rules), [Cardinality](#cardinality-rules), [Flag](#flag-rules), [Insert](#insert-rules), [Obeys](#obeys-rules), [Path](#path-rules), and [Type](#type-rules). The following limitations apply:
 
 * Binding, cardinality, and type rules SHALL be applied only to elements defined by the item (not inherited elements).
-* Flag rules SHALL NOT include MS flags.
+* Flag rules SHALL NOT include `MS` flags.
 * Assignment rules SHALL be used only with caret paths.
 
 The latter restrictions stem from FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements that are prohibited in that table. For example, the table indicates that setting `maxLength` or `mustSupport` is prohibited.

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -253,7 +253,7 @@ This syntax is also used with CodeableConcepts (see [Assignments with the Codeab
 
 **Examples:**
 
-* The code postal used in Address.type:
+* The code postal used in `Address.type`:
 
   ```
   #postal
@@ -395,13 +395,13 @@ FSH path grammar allows you to refer to any element of a profile, extension, or 
 * Metadata elements of definitional resources, such as the experimental and active elements of a StructureDefinition.
 * Properties of ElementDefinitions nested within a StructureDefinition, such as the maxLength property of string elements
 
-> **Note:** While FSH paths often resemble other path syntaxes used in FHIR (e.g., FHIRPath, ElementDefinition.id, ElementDefinition.path), they cannot be used in place of these. Attempts to use FSH paths within FHIRPath strings or as Element ids will lead to invalid FHIR output.
+> **Note:** While FSH paths often resemble other path syntaxes used in FHIR (e.g., FHIRPath, `ElementDefinition.id`, `ElementDefinition.path`), they cannot be used in place of these. Attempts to use FSH paths within FHIRPath strings or as Element ids will lead to invalid FHIR output.
 
 In the following, the various types of path references are discussed. Some examples are presented using simple rules. For rule syntax and meaning, see [FSH Rules](#fsh-rules).
 
 #### Top-Level Paths
 
-The path to a top-level element SHALL be denoted by the element's name. Because paths are used within the context of a FSH definition or instance, the path MUST NOT include the resource name. For example, when defining a profile of Observation, the path to Observation.code is just `code`.
+The path to a top-level element SHALL be denoted by the element's name. Because paths are used within the context of a FSH definition or instance, the path MUST NOT include the resource name. For example, when defining a profile of Observation, the path to `Observation.code` is just `code`.
 
 **Example:**
 
@@ -457,19 +457,19 @@ Elements can offer a choice of reference types. In the FHIR specification, these
 
 #### Data Type Choice [x] Paths
 
-FHIR represents an element with a choice of datatypes using the style foo[x]. For example, Condition.onset[x] can be a dateTime, Age, Period, Range or string. In FSH, [as in FHIR](https://hl7.org/fhir/R5/formats.html#choice), to refer to one of these datatypes, the `[x]` SHALL be replaced by the datatype name, capitalizing the first letter. For Condition.onset[x], the individual choices are onsetDateTime, onsetAge, onsetPeriod, onsetRange, and onsetString.
+FHIR represents an element with a choice of datatypes using the style foo[x]. For example, `Condition.onset[x]` can be a dateTime, Age, Period, Range or string. In FSH, [as in FHIR](https://hl7.org/fhir/R5/formats.html#choice), to refer to one of these datatypes, the `[x]` SHALL be replaced by the datatype name, capitalizing the first letter. For `Condition.onset[x]`, the individual choices are onsetDateTime, onsetAge, onsetPeriod, onsetRange, and onsetString.
 
 > **Note:** foo[x] choices are NOT represented as foo[dateTime], foo[Period], etc.
 
 **Examples:**
 
-* The path to the string datatype of Observation.value[x]:
+* The path to the string datatype of `Observation.value[x]`:
 
   ```
   valueString
   ```
 
-* The path to the Reference datatype choice of Medication.ingredient.item[x]:
+* The path to the Reference datatype choice of `Medication.ingredient.item[x]`:
 
   ```
   ingredient.itemReference
@@ -489,7 +489,7 @@ Numerical indices apply only to arrays that can be populated with concrete value
 
 **Examples:**
 
-* Path to first element in Patient.name field within an instance of Patient:
+* Path to first element in `Patient.name` field within an instance of Patient:
 
   ```
   name[0]
@@ -669,12 +669,12 @@ For locally-defined extensions, using the slice name is the simplest choice. For
 
 The FSH syntax provides a level of abstraction over FHIR resources. When authors define a Profile, Extension, Logical, or Resource using FSH, they are creating and modifying an instance of an underlying FHIR StructureDefinition. Similarly, when authors define a CodeSystem or ValueSet, they are creating and modifying an instance of a FHIR CodeSystem or FHIR ValueSet. While the basic FSH syntax maps to the core aspects of each of these FHIR definitional resources, it does not provide a complete mapping to every possible element within them.
 
-In order to address this gap, FSH authors MAY use the caret (`^`) symbol to access elements of definitional resources corresponding to the current item in context. Caret paths SHALL be accepted in FSH Profiles, Extensions, Logicals, and Resources to address elements in the underlying FHIR StructureDefinition resource; in FSH Invariants to address elements in the underlying ElementDefinition.constraint; in FSH ValueSets to address elements in the underlying FHIR ValueSet resource; in FSH CodeSystems to address elements in the underlying FHIR CodeSystem resource; and in FSH RuleSets, as long as the RuleSet is inserted in an item that allows caret paths. Caret paths SHALL NOT be used with any other FSH item definition, including Instances, since Instances already directly manipulate FHIR resources. In addition, caret syntax SHALL NOT be used with the following paths, because the order of elements in these paths MAY vary between implementations:
+In order to address this gap, FSH authors MAY use the caret (`^`) symbol to access elements of definitional resources corresponding to the current item in context. Caret paths SHALL be accepted in FSH Profiles, Extensions, Logicals, and Resources to address elements in the underlying FHIR StructureDefinition resource; in FSH Invariants to address elements in the underlying `ElementDefinition.constraint`; in FSH ValueSets to address elements in the underlying FHIR ValueSet resource; in FSH CodeSystems to address elements in the underlying FHIR CodeSystem resource; and in FSH RuleSets, as long as the RuleSet is inserted in an item that allows caret paths. Caret paths SHALL NOT be used with any other FSH item definition, including Instances, since Instances already directly manipulate FHIR resources. In addition, caret syntax SHALL NOT be used with the following paths, because the order of elements in these paths MAY vary between implementations:
 
 * `snapshot.element` and `differential.element` in Profile, Extension, Logical, and Resource items
 * `compose.include` and `compose.exclude` in ValueSet items
 
-Examples of elements that require the caret syntax include StructureDefinition.experimental, StructureDefinition.abstract and ValueSet.purpose. The caret syntax also provides a simple way to set metadata attributes in the ElementDefinitions that comprise the snapshot and differential tables (e.g., short, meaningWhenMissing, and various [slicing discriminator properties](#step-1-specify-the-slicing-logic)).
+Examples of elements that require the caret syntax include `StructureDefinition.experimental`, `StructureDefinition.abstract` and `ValueSet.purpose`. The caret syntax also provides a simple way to set metadata attributes in the ElementDefinitions that comprise the snapshot and differential tables (e.g., short, meaningWhenMissing, and various [slicing discriminator properties](#step-1-specify-the-slicing-logic)).
 
 For a path to an element of a StructureDefinition, excluding the differential and snapshot, use the following syntax inside a Profile, Extension, Logical, or Resource:
 
@@ -690,7 +690,7 @@ For a path to an element of an ElementDefinition within a StructureDefinition, u
 
 **Note:** When using caret paths to access metadata of element definitions, there is a REQUIRED space before the `^` character.
 
-A special case of the ElementDefinition path is setting properties of the first element of the differential (i.e., StructureDefinition.differential.element[0]). This element always refers to the profile or standalone extension itself. Since this element does not correspond to a named element appearing in an instance, the dot or full stop (`.`) SHALL be used to represent it (The dot symbol is often used to represent "current context" in other languages). It is important to note that the "self" elements are not the elements of a StructureDefinition directly, but elements of the first ElementDefinition contained in the StructureDefinition. The syntax is:
+A special case of the ElementDefinition path is setting properties of the first element of the differential (i.e., `StructureDefinition.differential.element[0]`). This element always refers to the profile or standalone extension itself. Since this element does not correspond to a named element appearing in an instance, the dot or full stop (`.`) SHALL be used to represent it (The dot symbol is often used to represent "current context" in other languages). It is important to note that the "self" elements are not the elements of a StructureDefinition directly, but elements of the first ElementDefinition contained in the StructureDefinition. The syntax is:
 
 ```
 . ^<element of StructureDefinition.differential[0]>
@@ -698,13 +698,13 @@ A special case of the ElementDefinition path is setting properties of the first 
 
 **Examples:**
 
-* In a profile definition, path to the corresponding StructureDefinition.experimental attribute:
+* In a profile definition, path to the corresponding `StructureDefinition.experimental` attribute:
 
   ```
   ^experimental
   ```
 
-* In a profile of Patient, the path to binding.description in the ElementDefinition corresponding to communication.language:
+* In a profile of Patient, the path to `binding.description` in the ElementDefinition corresponding to `communication.language`:
 
   ```
   communication.language ^binding.description
@@ -965,7 +965,7 @@ Additional levels to any depth SHALL be added in the same manner.
 
 ##### Code Metadata
 
-Within a CodeSystem definition, the caret syntax MAY be used to set metadata attributes for individual concepts (e.g., elements of CodeSystem.concept.designation and CodeSystem.concept.property).
+Within a CodeSystem definition, the caret syntax MAY be used to set metadata attributes for individual concepts (e.g., elements of `CodeSystem.concept.designation` and `CodeSystem.concept.property`).
 
 For a path to a code within a code system, use this syntax:
 
@@ -975,7 +975,7 @@ For a path to a code within a code system, use this syntax:
 
 **Examples:**
 
-* To set the designation.use of the code `#active`:
+* To set the `designation.use` of the code `#active`:
 
   ```
   * #active ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
@@ -1310,11 +1310,11 @@ These conformance resources MAY be created using FSH instance grammar. For examp
 
 #### Defining Invariants
 
-Invariants are defined using the REQUIRED declaration `Invariant`, RECOMMENDED keyword `Description`<sup>1</sup>, and OPTIONAL keywords `Severity`<sup>2</sup>, `XPath` (FHIR R4 only) and  `Expression`. The keywords correspond directly to elements in ElementDefinition.constraint, as shown in the table below. Invariants are incorporated into profiles, extensions, logical models, or resources via [obeys rules](#obeys-rules).
+Invariants are defined using the REQUIRED declaration `Invariant`, RECOMMENDED keyword `Description`<sup>1</sup>, and OPTIONAL keywords `Severity`<sup>2</sup>, `XPath` (FHIR R4 only) and  `Expression`. The keywords correspond directly to elements in `ElementDefinition.constraint`, as shown in the table below. Invariants are incorporated into profiles, extensions, logical models, or resources via [obeys rules](#obeys-rules).
 
 <span class="caption" id="t8">Table 8. Keywords used to define Invariants</span>
 
-| Keyword | Usage | Corresponding element in <br/> ElementDefinition.constraint | Data Type | Required |
+| Keyword | Usage | Corresponding element in <br/> `ElementDefinition.constraint` | Data Type | Required |
 |-------------|-----------------------------------|------------|-----------------|----------------|
 | Invariant   | Identifier for the invariant      | key        | id              | yes            |
 | Description | Human description of constraint   | human      | string          | no<sup>1</sup> |
@@ -1324,7 +1324,7 @@ Invariants are defined using the REQUIRED declaration `Invariant`, RECOMMENDED k
 {: .grid }
 
 {%include tu-div.html%}
-Rule types that apply to defining Invariants are: [Assignment](#assignment-rules), [Path](#path-rules), and [Insert](#insert-rules). Paths in Invariant assignment rules refer to elements within ElementDefinition.constraint (e.g., `severity` refers to `ElementDefinition.constraint.severity`). Assignment rules are particularly useful for specifying constraint extensions such as the [Best Practice](https://hl7.org/fhir/extensions/StructureDefinition-elementdefinition-bestpractice.html) extension.
+Rule types that apply to defining Invariants are: [Assignment](#assignment-rules), [Path](#path-rules), and [Insert](#insert-rules). Paths in Invariant assignment rules refer to elements within `ElementDefinition.constraint` (e.g., `severity` refers to `ElementDefinition.constraint.severity`). Assignment rules are particularly useful for specifying constraint extensions such as the [Best Practice](https://hl7.org/fhir/extensions/StructureDefinition-elementdefinition-bestpractice.html) extension.
 
 <sup>1</sup>If the `Description` keyword is not specified, then the definition MUST contain an assignment rule for the `human` element.
 <br/>
@@ -1452,9 +1452,9 @@ The mappings themselves are declared in rules with the following syntaxes:
 * &lt;element&gt; -> "{map string}" <span class="optional">"{comment string}" #{mime-type code}</span>
 </code></pre>
 
-A rule starting with the characters `->` SHALL map the profile as a whole to a target. A rule starting with an element followed by the characters `->` SHALL map a specific element within the source to a target. The `map`, `comment`, and `mime-type` are as defined in FHIR and correspond to elements in [StructureDefinition.mapping](https://hl7.org/fhir/structuredefinition.html) and [ElementDefinition.mapping](https://hl7.org/fhir/R5/elementdefinition.html) (map corresponds to mapping.map, mime-type to mapping.language, and comment to mapping.comment). The mime type code MUST come from FHIR's [MimeType value set](https://hl7.org/fhir/R5/valueset-mimetypes.html). For further information, refer to the FHIR definitions of these elements.
+A rule starting with the characters `->` SHALL map the profile as a whole to a target. A rule starting with an element followed by the characters `->` SHALL map a specific element within the source to a target. The `map`, `comment`, and `mime-type` are as defined in FHIR and correspond to elements in [StructureDefinition.mapping](https://hl7.org/fhir/structuredefinition.html) and [ElementDefinition.mapping](https://hl7.org/fhir/R5/elementdefinition.html) (map corresponds to `mapping.map`, mime-type to `mapping.language`, and comment to `mapping.comment`). The mime type code MUST come from FHIR's [MimeType value set](https://hl7.org/fhir/R5/valueset-mimetypes.html). For further information, refer to the FHIR definitions of these elements.
 
->**Note:** Unlike setting the mapping.map directly in the StructureDefinition, mapping rules within a Mapping item MUST NOT include the name of the resource in the path on the left hand side.
+>**Note:** Unlike setting the `mapping.map` directly in the StructureDefinition, mapping rules within a Mapping item MUST NOT include the name of the resource in the path on the left hand side.
 
 Rule types that apply to Mappings are: [Insert](#insert-rules), [Mapping](#mapping-rules), and [Path](#path-rules).
 
@@ -1466,7 +1466,7 @@ Rule types that apply to Mappings are: [Insert](#insert-rules), [Mapping](#mappi
   * -> "Patient" "This profile maps to Patient in Argonaut"
   ```
 
-* Map the identifier.value element from one IG to another:
+* Map the `identifier.value` element from one IG to another:
 
   ```
   * identifier.value -> "Patient.identifier.value"
@@ -1771,7 +1771,7 @@ A filter is a logical statement in the form `{property} {operator} {value}`, whe
 
 ##### Concept Metadata
 
-Within a ValueSet definition, the caret syntax MAY be used to set metadata attributes for individual concepts (e.g., elements of ValueSet.compose.include.concept.designation).
+Within a ValueSet definition, the caret syntax MAY be used to set metadata attributes for individual concepts (e.g., elements of `ValueSet.compose.include.concept.designation`).
 
 To assign metadata values for concepts that are included in the value set, authors SHOULD specify one or more indented caret path assignment rules below the rule that includes the concept:
 <pre><code>* <span class="optional">include</span> {Coding}
@@ -1919,7 +1919,7 @@ When indented rules are combined with [soft indexing](#array-paths-using-soft-in
 
 **Examples:**
 
-* Use indented rules to set cardinalities on name.family and name.given in a Patient resource:
+* Use indented rules to set cardinalities on `name.family` and `name.given` in a Patient resource:
 
   ```
   * name 1..1
@@ -2203,7 +2203,7 @@ This is best illustrated by example. Consider the following assignment (assuming
 * code = https://loinc.org#69548-6
 ```
 
-If this statement appears in an instance of an Observation, then the values of code.coding[0].system and code.coding[0].code will be set to https://loinc.org and 69548-6, respectively, in that Observation.
+If this statement appears in an instance of an Observation, then the values of `code.coding[0].system` and `code.coding[0].code` will be set to https://loinc.org and 69548-6, respectively, in that Observation.
 
 If the identical statement appears in a profile on Observation, it signals that the StructureDefinition is configured such that the code element of a conformant instance MUST have a Coding with the system http://loinc.org and the code 69548-6. (In fact, the StructureDefinition does not even *have* a code element to populate.)
 
@@ -2301,7 +2301,7 @@ Whenever this type of rule is applied, whatever is on the right side SHALL **ent
   * myCoding.userSelected = true
   ```
   
-* In an instance of a Signature, set Signature.type (a Coding datatype):
+* In an instance of a Signature, set `Signature.type` (a Coding datatype):
 
   ```
   * type = urn:iso-astm:E1762-95:2013#1.2.840.10065.1.12.1.2 "Coauthor's Signature"
@@ -2424,7 +2424,7 @@ A similar shorthand MAY be used for other code systems by specifying the unit us
 
 <pre><code>* &lt;Quantity&gt; = {decimal} {CodeSystem}<span class="optional">|{version string}</span>#{code} <span class="optional">"{units display string}"</span></code></pre>
 
-Alternatively, the value and units MAY also be set independently. To assign a value, use the Quantity.value property:
+Alternatively, the value and units MAY also be set independently. To assign a value, use the `Quantity.value` property:
 
 ```
 * <Quantity>.value = {decimal}
@@ -2452,13 +2452,13 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
   * valueQuantity = 55.0 'mm' "millimeter"
   ```
 
-* Set the numerical value of Observation.valueQuantity to 55.0 without setting the units:
+* Set the numerical value of `Observation.valueQuantity` to 55.0 without setting the units:
 
   ```
   * valueQuantity.value = 55.0
   ```
 
-* Set the units of Observation.valueQuantity to millimeters, using UCUM units and a display string, without setting the value:
+* Set the units of `Observation.valueQuantity` to millimeters, using UCUM units and a display string, without setting the value:
 
   ```
   * valueQuantity = 'mm' "millimeter"
@@ -2470,7 +2470,7 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
   * valueQuantity = 155.0 http://terminology.hl7.org/CodeSystem/umls#C0439219 "pounds"
   ```
 
-* Set the units of Observation.valueQuantity to pounds, using the UMLS unit code (not recommended) and a display string, without setting the value (assuming $UMLS has been defined as an alias for http://terminology.hl7.org/CodeSystem/umls): 
+* Set the units of `Observation.valueQuantity` to pounds, using the UMLS unit code (not recommended) and a display string, without setting the value (assuming $UMLS has been defined as an alias for http://terminology.hl7.org/CodeSystem/umls): 
 
   ```
   * valueQuantity = $UMLS#C0439219 "pounds"
@@ -2505,7 +2505,7 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
 
 ##### Assignments Involving References
 
-Resource instances MAY refer to other resource instances. The referred resources can either exist independently or be contained inline in the DomainResource.contained array. Less commonly, the value of an element can be a resource, rather than a reference to a resource.
+Resource instances MAY refer to other resource instances. The referred resources can either exist independently or be contained inline in the `DomainResource.contained` array. Less commonly, the value of an element can be a resource, rather than a reference to a resource.
 
 A resource reference is assigned using this syntax:
 
@@ -2523,7 +2523,7 @@ As [advised in FHIR](https://hl7.org/fhir/R5/references.html#canonical), the URL
 
 **Examples:**
 
-* Assignment of a reference to an example of a Patient resource to Observation.subject:
+* Assignment of a reference to an example of a Patient resource to `Observation.subject`:
 
   ```
   * subject = Reference(EveAnyperson)
@@ -2540,7 +2540,7 @@ As [advised in FHIR](https://hl7.org/fhir/R5/references.html#canonical), the URL
   * name.family = "Anyperson"
   ```
 
-* Assignment of the same instance in Bundle.entry.resource, whose datatype is Resource (not Reference(Resource)):
+* Assignment of the same instance in `Bundle.entry.resource`, whose datatype is Resource (not Reference(Resource)):
 
   ```
   * entry[0].resource = EveAnyperson
@@ -2556,7 +2556,7 @@ To assign values to a CodeableReference, authors MAY assign a FSH Coding or refe
 
 **Examples:**
 
-* Constrain Substance.code, which is datatype `CodeableReference(SubstanceDefinition)` in FHIR R5:
+* Constrain `Substance.code`, which is datatype `CodeableReference(SubstanceDefinition)` in FHIR R5:
 
   ```
   Profile: LatexSubstance
@@ -2611,14 +2611,14 @@ When the left side of an assignment rule contains a caret path, the value SHALL 
   * ^url = "http://example.org/custom/myextension"
   ```
 
-* Assign the short description and definition for the Observation.value[x] ElementDefinition in an Observation profile:
+* Assign the short description and definition for the `Observation.value[x]` ElementDefinition in an Observation profile:
 
   ```
   * value[x] ^short = "Measurement in cm"
   * value[x] ^definition = "The measurement in centimeters. Values in other units must be converted to centimeters in order to conform with this profile."
   ```
 
-* Assign the short description and definition for the Observation.value[x] ElementDefinition in an Observation profile using [indented rules](#indented-rules):
+* Assign the short description and definition for the `Observation.value[x]` ElementDefinition in an Observation profile using [indented rules](#indented-rules):
 
   ```
   * value[x]
@@ -2626,7 +2626,7 @@ When the left side of an assignment rule contains a caret path, the value SHALL 
     * ^definition = "The measurement in centimeters. Values in other units must be converted to centimeters in order to conform with this profile."
   ```
 
-* Assign [code metadata](#code-metadata) designation.use for the `#active` code within a CodeSystem:
+* Assign [code metadata](#code-metadata) `designation.use` for the `#active` code within a CodeSystem:
 
   ```
   * #active ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
@@ -2846,7 +2846,7 @@ The slicing logic parameters MUST be specified using [caret paths](#caret-paths)
 
 **Example:**
 
-* Provide slicing logic for slices on Observation.component that are to be distinguished by their code:
+* Provide slicing logic for slices on `Observation.component` that are to be distinguished by their code:
 
   ```
   * component ^slicing.discriminator.type = #pattern
@@ -2872,15 +2872,15 @@ In this pattern, `<array>` is a path to the element that is to be sliced and MUS
 
 Each slice matches or constrains the datatype of the array it slices. In particular:
 
-* If the sliced element is an array of a FHIR datatype, each slice will be the same datatype or a profile of it. For example, if Observation.identifier is sliced, each slice will have type Identifier or be constrained to a profile of the Identifier datatype.
-* If the sliced element is an array of a backbone element, each slice "inherits" the sub-elements of the backbone. For example, the slices of Observation.component possess all the elements of Observation.component (code, value[x], dataAbsentReason, etc.). Constraints MAY be applied to the slices.
+* If the sliced element is an array of a FHIR datatype, each slice will be the same datatype or a profile of it. For example, if `Observation.identifier` is sliced, each slice will have type Identifier or be constrained to a profile of the Identifier datatype.
+* If the sliced element is an array of a backbone element, each slice "inherits" the sub-elements of the backbone. For example, the slices of `Observation.component` possess all the elements of `Observation.component` (code, value[x], dataAbsentReason, etc.). Constraints MAY be applied to the slices.
 * If the sliced element is an array of a Reference, then each slice MUST be a reference to one or more of the allowed Reference types. For example, if the element to be sliced is Reference(Observation or Condition), then each slice MUST either be Reference(Observation or Condition), Reference(Observation), Reference(Condition), or a profiled version of those resources.
 
 FSH implementations MUST add new slices to the StructureDefinition in the order in which they appear within the contains rule. When a FSH definition has multiple contains rules on the same path, these rules MUST be processed in the order in which they appear.
 
 **Examples:**
 
-* Slice the Observation.component array for blood pressure:
+* Slice the `Observation.component` array for blood pressure:
 
   ```
   * component contains systolicBP 1..1 MS and diastolicBP 1..1 MS
@@ -3359,7 +3359,7 @@ The referenced invariant and its properties MUST be declared somewhere within th
   * obeys us-core-9
   ```
 
-* Assign invariant to Patient.name in US Core Patient:
+* Assign invariant to `Patient.name` in US Core Patient:
 
   ```
   * name obeys us-core-8
@@ -3407,7 +3407,7 @@ Path rules MAY also be used to indicate the order for slices to appear in an Ins
 
 * Include optional fixed values of a path in an Instance:
 
-  * Given a profile where name.family is optional and has a fixed value, such as:
+  * Given a profile where `name.family` is optional and has a fixed value, such as:
 
     ```
     * name.family = "Smith"
@@ -3462,9 +3462,9 @@ FSH rules MAY also be used to restrict the target types of CodeableReference ele
 ```
 </div>
 
-Certain elements in FHIR offer a choice of datatypes using the [x] syntax. Choices also frequently appear in references. For example, Condition.recorder has the choice Reference(Practitioner or PractitionerRole or Patient or RelatedPerson). In both cases, choices MAY be restricted in two ways: reducing the number or choices, and/or substituting a more restrictive datatype or profile for one of the choices appearing in the parent profile or resource. In some cases, the right-hand side of a type rule MAY have a combination of datatype, Reference, Canonical, and {%include tu-span.html%}CodeableReference<span> targets.
+Certain elements in FHIR offer a choice of datatypes using the [x] syntax. Choices also frequently appear in references. For example, `Condition.recorder` has the choice Reference(Practitioner or PractitionerRole or Patient or RelatedPerson). In both cases, choices MAY be restricted in two ways: reducing the number or choices, and/or substituting a more restrictive datatype or profile for one of the choices appearing in the parent profile or resource. In some cases, the right-hand side of a type rule MAY have a combination of datatype, Reference, Canonical, and {%include tu-span.html%}CodeableReference<span> targets.
 
-Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5/profiling.html), the datatype(s) in a type rule MUST always be more restrictive than the original datatype. For example, if the parent datatype is Quantity, it MAY be replaced by SimpleQuantity, since SimpleQuantity is a profile on Quantity (hence more restrictive than Quantity itself), but MUST NOT be replaced with Ratio, because Ratio is not a type of Quantity. Similarly, Condition.subject, defined as Reference(Patient or Group), MAY be constrained to Reference(Patient), Reference(Group), or Reference(us-core-patient), but MUST NOT be restricted to Reference(RelatedPerson), since that is neither a Patient nor a Group.
+Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5/profiling.html), the datatype(s) in a type rule MUST always be more restrictive than the original datatype. For example, if the parent datatype is Quantity, it MAY be replaced by SimpleQuantity, since SimpleQuantity is a profile on Quantity (hence more restrictive than Quantity itself), but MUST NOT be replaced with Ratio, because Ratio is not a type of Quantity. Similarly, `Condition.subject`, defined as Reference(Patient or Group), MAY be constrained to Reference(Patient), Reference(Group), or Reference(us-core-patient), but MUST NOT be restricted to Reference(RelatedPerson), since that is neither a Patient nor a Group.
 
 **Examples:**
 
@@ -3474,7 +3474,7 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
   * valueQuantity only SimpleQuantity
   ```
 
-* Condition.onset[x] is a choice of dateTime, Age, Period, Range or string. To restrict onset[x] to dateTime:
+* `Condition.onset[x]` is a choice of dateTime, Age, Period, Range or string. To restrict onset[x] to dateTime:
 
   ```
   * onset[x] only dateTime
@@ -3502,7 +3502,7 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
 
 </div>
 
-* Restrict Observation.performer (nominally Reference(Practitioner \| PractitionerRole \| Organization \| CareTeam \| Patient \| RelatedPerson)) to allow only Practitioner:
+* Restrict `Observation.performer` (nominally Reference(Practitioner \| PractitionerRole \| Organization \| CareTeam \| Patient \| RelatedPerson)) to allow only Practitioner:
 
   ```
   * performer only Reference(Practitioner)
@@ -3533,26 +3533,26 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
   * performer only Reference(Practitioner or PractitionerRole)
   ```
 
-* Restrict PlanDefinition.action.definition[x], nominally a choice of uri or canonical(ActivityDefinition \| PlanDefinition \| Questionnaire), to allow only the canonical of an ActivityDefinition:
+* Restrict `PlanDefinition.action.definition[x]`, nominally a choice of uri or canonical(ActivityDefinition \| PlanDefinition \| Questionnaire), to allow only the canonical of an ActivityDefinition:
 
   ```
   * action.definition[x] only Canonical(ActivityDefinition)
   ```
 
-* Restrict action.definition[x] to a canonical of either an ActivityDefinition or a PlanDefinition:
+* Restrict `PlanDefinition.action.definition[x]` to a canonical of either an ActivityDefinition or a PlanDefinition:
 
   ```
   * action.definition[x] only Canonical(ActivityDefinition or PlanDefinition)
   ```
 
 {%include tu-div.html%}
-* Restrict MedicationRequest.reason, a choice of CodeableReference(Condition \| Observation), to allow only a CodeableReference to an Observation
+* Restrict `MedicationRequest.reason`, a choice of CodeableReference(Condition \| Observation), to allow only a CodeableReference to an Observation
 
   ```
   * reason only CodeableReference(Observation)
   ```
 
-* Restrict CarePlan.activity.performedActivity to a CodeableReference of an Encounter or a Procedure:
+* Restrict `CarePlan.activity.performedActivity` to a CodeableReference of an Encounter or a Procedure:
 
   ```
   * activity.performedActivity only CodeableReference(Encounter or Procedure)

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -661,7 +661,7 @@ For locally-defined extensions, using the slice name is the simplest choice. For
   extension[ethnicity].extension[ombCategory].valueCoding
   ```
 
-* Path to the Coding value in second element in the nested extension array named detailed, under USCoreEthnicity extension:
+* Path to the Coding value in second element in the nested extension array named detailed, under the US Core Ethnicity extension:
 
   ```
   extension[ethnicity].extension[detailed][1].valueCoding
@@ -2805,7 +2805,7 @@ In these expressions, the names (`name`, `name1`, `name2`, etc.) are new local n
   * modifierExtension contains $DoNotPerform named doNotPerform 0..1 MS
   ```
 
-* Add a standalone extension Laterality, defined in the same FSH project, to a `bodySite` attribute (second level extension):
+* Add a standalone extension `Laterality`, defined in the same FSH project, to a `bodySite` attribute (second level extension):
 
   ```
   * bodySite.extension contains Laterality named laterality 0..1
@@ -3124,7 +3124,7 @@ Any FSH syntax errors that arise as a result of the value substitution SHALL be 
 
 **Examples:**
 
-* Use the parameterized rule set, Name, to populate an instance of Patient with multiple names (note that the curly brackets in this example are literal, not syntax expressions):
+* Use the parameterized rule set, `Name`, to populate an instance of Patient with multiple names (note that the curly brackets in this example are literal, not syntax expressions):
 
   ```
   RuleSet: Name(first, last)
@@ -3161,7 +3161,7 @@ Any FSH syntax errors that arise as a result of the value substitution SHALL be 
   // more rules
   ```
 
-* Use the parameterized rule set, Phone, to add a phone number to an instance of Organization (note the use of backslash to escape a closing parenthesis):
+* Use the parameterized rule set, `Phone`, to add a phone number to an instance of Organization (note the use of backslash to escape a closing parenthesis):
 
   ```
   RuleSet: Phone(value)
@@ -3193,7 +3193,7 @@ Any FSH syntax errors that arise as a result of the value substitution SHALL be 
   ```
 
 {%include tu-div.html%}
-* Use the parameterized rule set, AddVariableToTestScript, to add variable definitions to an instance of TestScript (note the use of double brackets to avoid the need to escape closing parentheses and commas):
+* Use the parameterized rule set, `AddVariableToTestScript`, to add variable definitions to an instance of TestScript (note the use of double brackets to avoid the need to escape closing parentheses and commas):
 
   ```
   RuleSet: AddVariableToTestScript(name, expression)

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -983,7 +983,7 @@ For a path to a code within a code system, use this syntax:
   * #active ^designation[0].use = $SCT#900000000000003001 "Fully specified name"
   ```
 
-* The path to the property code of #recurrence code, a child of the #active code:
+* The path to the property code of `#recurrence` code, a child of the `#active` code:
 
   ```
   #active #recurrence ^property[0].code

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -195,7 +195,7 @@ FSH strings follow the same rules and support the same content as the [FHIR stri
 
 #### References
 
-FHIR elements can contain [references to other Resources](https://hl7.org/fhir/R5/references.html#2.1.3.0). FSH represents references using the syntax `Reference({Resource/Profile})`. A resource or profile SHALL be identifiable by name, id, or URL. For example, `Reference(USCorePatientProfile)`, `Reference(us-core-patient)`, and `Reference(http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient)` all are valid references to the [US Core Patient profile](https://hl7.org/fhir/us/core/structuredefinition-us-core-patient.html). When referring to a Reference element, the `Reference()` MUST be included, except in the case of a [reference choice path](#reference-paths). When syntax allows for multiple References, the items MUST be separated by `or` placed *inside* the parentheses, e.g. `Reference(Patient or Practitioner)`, **not** `Reference(Patient) or Reference(Practitioner)`. 
+FHIR elements can contain [references to other Resources](https://hl7.org/fhir/R5/references.html#2.1.3.0). FSH represents references using the syntax `Reference({Resource/Profile})`. A resource or profile SHALL be identifiable by name, id, or URL. For example, `Reference(USCorePatientProfile)`, `Reference(us-core-patient)`, and `Reference(http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient)` all are valid references to the [US Core Patient profile](https://hl7.org/fhir/us/core/structuredefinition-us-core-patient.html). When referring to a Reference element, the `Reference()` MUST be included, except in the case of a [reference choice path](#reference-paths). When syntax allows for a FSH Reference with multiple targets, the items MUST be separated by `or` placed *inside* the parentheses, e.g. `Reference(Patient or Practitioner)`, **not** `Reference(Patient) or Reference(Practitioner)`. 
 
 In constructing profiles, references typically refer to resource or profile *types*, for example, the subject of an Observation could be constrained to `Reference(Patient or Group)`. Inside instances, references typically refer to other instances, for example, a subject of an Observation could be `Reference(JaneDoe)`, assuming JaneDoe is the id of a Patient instance. In this case, since `JaneDoe` is a Patient instance, `Reference(JaneDoe)` is resolved to `Patient/JaneDoe`. If a reference value in an instance does not reference a known instance, implementations MUST use the value directly. For example, if the subject of an Observation is `Reference(Alice)`, and Alice is not the name, id, or URL of a known Patient instance, the reference resolves to `Alice`.
 
@@ -205,7 +205,7 @@ FHIR elements can reference other resources by their [canonical URL](https://hl7
 
 For items defined in the same FSH project, implementations MUST construct the canonical URL using the FSH project's canonical URL. `Canonical()` therefore enables a user to change the FSH project’s canonical URL in a single place with no changes to FSH definitions.
 
-When syntax allows for multiple Canonicals, the items MUST be separated by `or` placed *inside* the parentheses, e.g. `Canonical(ActivityDefinition or PlanDefinition)`, **not** `Canonical(ActivityDefinition) or Canonical(PlanDefinition)`.
+When syntax allows for a FSH Canonical with multiple targets, the items MUST be separated by `or` placed *inside* the parentheses, e.g. `Canonical(ActivityDefinition or PlanDefinition)`, **not** `Canonical(ActivityDefinition) or Canonical(PlanDefinition)`.
 
 **Examples:**
 
@@ -313,7 +313,7 @@ or
 
 <pre><code>{decimal} {CodeSystem}<span class="optional">|{version string}</span>#{code} <span class="optional">"{display}"</span></code></pre>
 
-The first shorthand syntax only applies if the units are expressed in [Unified Code for Units of Measure](http://unitsofmeasure.org/) (UCUM). When this syntax is used, implementations MUST set the code system (`Quantity.system`) to the UCUM code system (`http://unitsofmeasure.org`). The second shorthand MAY be used when the units are not UCUM. Alternatively, the value and units MAY be assigned independently (see [Assignments with the Quantity Data Type](#assignments-with-the-quantity-data-type)).
+The first shorthand syntax only applies if the units are expressed in [Unified Code for Units of Measure](http://unitsofmeasure.org/) (UCUM). When this syntax is used, implementations MUST set the code system (`Quantity.system`) to the UCUM code system (http://unitsofmeasure.org). The second shorthand MAY be used when the units are not UCUM. Alternatively, the value and units MAY be assigned independently (see [Assignments with the Quantity Data Type](#assignments-with-the-quantity-data-type)).
 
 **Examples:**
 
@@ -519,7 +519,7 @@ Soft indexing is useful when populating long arrays, allowing elements to be ins
 
 Another use case for soft indexing involves [rule sets](#defining-rule-sets). Rule sets provide a way to avoid repeating the same pattern of rules when populating an array ([see example](#parameterized-rule-sets)).
 
-For nested arrays, several sequences of soft indices MAY run simultaneously. The sequence of indices at different levels of nesting SHALL be independent and SHALL NOT interact with one another. However, when arrays are nested, incrementing the index of the parent (outer) array advances to the next child (inner) array, so the next child element referred to by `[+]` SHALL be at index [0]. (An analogy is using a keyboard's Enter key to advance to a new line that initially has no characters.)
+For nested arrays, several sequences of soft indices MAY run simultaneously. The sequence of indices at different levels of nesting SHALL be independent and SHALL NOT interact with one another. However, when arrays are nested, incrementing the index of the parent (outer) array advances to the next child (inner) array, so the next child element referred to by `[+]` SHALL be at index 0. (An analogy is using a keyboard's Enter key to advance to a new line that initially has no characters.)
 
 **Examples:**
 
@@ -692,7 +692,7 @@ For a path to an element of an ElementDefinition within a StructureDefinition, u
 
 **Note:** When using caret paths to access metadata of element definitions, there is a REQUIRED space before the `^` character.
 
-A special case of the ElementDefinition path is setting properties of the first element of the differential (i.e., `StructureDefinition.differential.element[0]`). This element always refers to the profile or standalone extension itself. Since this element does not correspond to a named element appearing in an instance, the dot or full stop (`.`) SHALL be used to represent it (The dot symbol is often used to represent "current context" in other languages). It is important to note that the "self" elements are not the elements of a StructureDefinition directly, but elements of the first ElementDefinition contained in the StructureDefinition. The syntax is:
+A special case of the ElementDefinition path is setting properties of the first element of the differential (i.e., `StructureDefinition.differential.element[0]`). This element always refers to the profile or standalone extension itself. Since this element does not correspond to a named element appearing in an instance, the dot or full stop (`.`) SHALL be used to represent it. (The dot symbol is often used to represent "current context" in other languages.) It is important to note that the "self" elements are not the elements of a StructureDefinition directly, but elements of the first ElementDefinition contained in the StructureDefinition. The syntax is:
 
 ```
 . ^<element of StructureDefinition.differential[0]>
@@ -811,9 +811,9 @@ Depending on the type of item being defined, keywords may be REQUIRED, suggested
 
 **KEY:**  R = REQUIRED, S = suggested (SHOULD be used), O = OPTIONAL, blank = prohibited (MUST NOT be used)
 
-{%include tu-span.html%} <sup>1</sup>If the `Description` keyword is not specified in an `Invariant` definition, then an assignment rule for the `human` element MUST be specified instead.</span>
+{%include tu-span.html%} <sup>1</sup> If the `Description` keyword is not specified in an `Invariant` definition, then an assignment rule for the `human` element MUST be specified instead.</span>
 <br/>
-{%include tu-span.html%} <sup>2</sup>If the `Severity` keyword is not specified in an `Invariant` definition, then an assignment rule for the `severity` element MUST be specified instead.</span>
+{%include tu-span.html%} <sup>2</sup> If the `Severity` keyword is not specified in an `Invariant` definition, then an assignment rule for the `severity` element MUST be specified instead.</span>
 
 For additional information about the use of these keywords, consult the documentation pertaining to the specific item(s) to which they apply.
 
@@ -1328,9 +1328,9 @@ Invariants are defined using the REQUIRED declaration `Invariant`, RECOMMENDED k
 {%include tu-div.html%}
 Rule types that apply to defining Invariants are: [Assignment](#assignment-rules), [Path](#path-rules), and [Insert](#insert-rules). Paths in Invariant assignment rules refer to elements within `ElementDefinition.constraint` (e.g., `severity` refers to `ElementDefinition.constraint.severity`). Assignment rules are particularly useful for specifying constraint extensions such as the [Best Practice](https://hl7.org/fhir/extensions/StructureDefinition-elementdefinition-bestpractice.html) extension.
 
-<sup>1</sup>If the `Description` keyword is not specified, then the definition MUST contain an assignment rule for the `human` element.
+<sup>1</sup> If the `Description` keyword is not specified, then the definition MUST contain an assignment rule for the `human` element.
 <br/>
-<sup>2</sup>If the `Severity` keyword is not specified, then the definition MUST contain an assignment rule for the `severity` element.
+<sup>2</sup> If the `Severity` keyword is not specified, then the definition MUST contain an assignment rule for the `severity` element.
 </div>
 
 **Example:**
@@ -3115,7 +3115,7 @@ As indicated, the list of values MUST be enclosed with parentheses `()` and sepa
 {%include tu-div.html%}
 Alternatively, a parameter value MAY be surrounded by double square brackets `[[` `]]`. Literal `)` and `,` characters within the double square brackets SHOULD NOT be escaped with a backslash<sup>*</sup>. Use of double brackets makes sense when a parameter requires multiple escape characters.
 
-<sup>*</sup>The only exception to this is when the author wants to include `]],` or `]])` as part of the parameter value. In this case, the `)` or `,` following the `]]` MUST be escaped with a backslash. For example, to include `]],` as part of a parameter value within double square brackets, use `]]\,`. This MUST be done even if there is whitespace between the `]]` and `,` or `)`. For example, to include `]] )` as part of a parameter within double square brackets, use `]] \)`. Additionally, note that the full value MUST be surrounded with double square brackets in order for this type of processing to occur.
+<sup>*</sup> The only exception to this is when the author wants to include `]],` or `]])` as part of the parameter value. In this case, the `)` or `,` following the `]]` MUST be escaped with a backslash. For example, to include `]],` as part of a parameter value within double square brackets, use `]]\,`. This MUST be done even if there is whitespace between the `]]` and `,` or `)`. For example, to include `]] )` as part of a parameter within double square brackets, use `]] \)`. Additionally, note that the full value MUST be surrounded with double square brackets in order for this type of processing to occur.
 </div>
 
 The values provided SHALL be substituted into the named rule set to create the rules that will be applied. The number of values provided MUST match the number of parameters specified in the rule set definition.

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -2650,7 +2650,7 @@ Binding is the process of associating a coded element with a set of possible val
 
 The bindable types SHALL be the same as the bindable types in FHIR: [code, Coding, CodeableConcept, Quantity, string, and uri](https://hl7.org/fhir/R5/terminologies.html#4.1). In FHIR R5, {%include tu-span.html%} CodeableReference</span> SHALL also be bindable.
 
-The strengths SHALL be the same as the [binding strengths defined in FHIR](https://hl7.org/fhir/R5/valueset-binding-strength.html), namely: example, preferred, extensible, and required. If strength is not specified, a required binding SHALL be assumed.
+The strengths SHALL be the same as the [binding strengths defined in FHIR](https://hl7.org/fhir/R5/valueset-binding-strength.html), namely: `example`, `preferred`, `extensible`, and `required`. If strength is not specified, a required binding SHALL be assumed.
 
 The [binding rules defined in FHIR](https://hl7.org/fhir/R5/profiling.html#binding) SHALL be applicable to FSH. In particular:
 

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -279,13 +279,13 @@ This syntax is also used with CodeableConcepts (see [Assignments with the Codeab
   http://snomed.info/sct#363346000 "Malignant neoplastic disease (disorder)"
   ```
   
-* The same Coding, assuming $SCT has been defined as an alias for http://snomed.info/sct:
+* The same Coding, assuming `$SCT` has been defined as an alias for http://snomed.info/sct:
 
   ```
   $SCT#363346000 "Malignant neoplastic disease (disorder)"
   ```
   
-* A Coding from ICD10-CM, assuming the alias $ICD for that code system:
+* A Coding from ICD10-CM, assuming the alias `$ICD` for that code system:
 
   ```
   $ICD#C004 "Malignant neoplasm of lower lip, inner aspect"
@@ -2317,7 +2317,7 @@ Whenever this type of rule is applied, whatever is on the right side SHALL **ent
   ```
   Because the second assignment clears the previous value of `myCoding`, the result is:
 
-  * `myCoding.system` is http://hl7.org/fhir/sid/icd-10-cm (assuming the $ICD alias maps to this URL)
+  * `myCoding.system` is http://hl7.org/fhir/sid/icd-10-cm (assuming the `$ICD` alias maps to this URL)
   * `myCoding.code` is "C80.1"
   * `myCoding.display` **has no value**
   * `myCoding.version` **has no value**
@@ -2472,7 +2472,7 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
   * valueQuantity = 155.0 http://terminology.hl7.org/CodeSystem/umls#C0439219 "pounds"
   ```
 
-* Set the units of `Observation.valueQuantity` to pounds, using the UMLS unit code (not recommended) and a display string, without setting the value (assuming $UMLS has been defined as an alias for http://terminology.hl7.org/CodeSystem/umls): 
+* Set the units of `Observation.valueQuantity` to pounds, using the UMLS unit code (not recommended) and a display string, without setting the value (assuming `$UMLS` has been defined as an alias for http://terminology.hl7.org/CodeSystem/umls): 
 
   ```
   * valueQuantity = $UMLS#C0439219 "pounds"
@@ -2672,7 +2672,7 @@ The [binding rules defined in FHIR](https://hl7.org/fhir/R5/profiling.html#bindi
   * gender from http://hl7.org/fhir/ValueSet/administrative-gender
   ```
 
-* Bind to a value set using an alias name, assuming $AdGen is an alias for http://hl7.org/fhir/ValueSet/administrative-gender:
+* Bind to a value set using an alias name, assuming `$AdGen` is an alias for http://hl7.org/fhir/ValueSet/administrative-gender:
 
   ```
   * gender from $AdGen

--- a/input/pagecontent/reference.md
+++ b/input/pagecontent/reference.md
@@ -20,7 +20,7 @@ Syntax expressions use the following conventions:
 
 | Style | Explanation | Example |
 |:------------|:------|:---------|
-| `this is FSH` | Font used for FSH fragments, such as keywords, statements, and syntax expressions  | `* status = #open` |
+| `this is FSH` | Font used for FSH fragments, such as keywords, statements, and syntax expressions<sup>*</sup> | `* status = #open` |
 | `{ }` | Substitution: If a datatype, replace with a value; if an item, replace with a name, id, or URL | `{decimal}` |
 | `< >` | Indicates an element or path to an element with the given datatype MUST be substituted | `<CodeableConcept>` |
 | <span class="optional">orange color</span> | An OPTIONAL item in a syntax expression | <code><span class="optional">{flag}</span></code> |
@@ -28,6 +28,8 @@ Syntax expressions use the following conventions:
 | `/` | A choice of items | `Resource/Profile` |
 | **bold** | A directory path or file name | **example-1.fsh** |
 {: .grid }
+
+<sup>*</sup> NOTE: This specification also uses `code styling` for a selected set of non-FSH expressions, such as FHIR paths and element names (e.g., `Patient.name.given`, the Observation `value[x]` element).
 
 **Syntax Expression Examples:**
 
@@ -387,13 +389,13 @@ A FSH item within the same project SHOULD be referred to by the name or id given
 
 FSH path grammar allows you to refer to any element of a profile, extension, or instance, regardless of nesting. Here are examples of things paths can refer to:
 
-* Top-level elements such as the code element of an Observation
-* Nested elements, such as the text element of the method element of an Observation
-* Elements in a list or array, such as the second element in the name array of a Patient resource
-* Individual datatypes of choice elements, such as onsetAge in onset[x]
+* Top-level elements such as the `code` element of an Observation
+* Nested elements, such as the `text` element of the `method` element of an Observation
+* Elements in a list or array, such as the second element in the `name` array of a Patient resource
+* Individual datatypes of choice elements, such as `onsetAge` in `onset[x]`
 * Individual slices within a sliced array, such as the systolicBP component in a blood pressure Observation
-* Metadata elements of definitional resources, such as the experimental and active elements of a StructureDefinition.
-* Properties of ElementDefinitions nested within a StructureDefinition, such as the maxLength property of string elements
+* Metadata elements of definitional resources, such as the `experimental` and `active` elements of a StructureDefinition.
+* Properties of ElementDefinitions nested within a StructureDefinition, such as the `maxLength` property of string elements
 
 > **Note:** While FSH paths often resemble other path syntaxes used in FHIR (e.g., FHIRPath, `ElementDefinition.id`, `ElementDefinition.path`), they cannot be used in place of these. Attempts to use FSH paths within FHIRPath strings or as Element ids will lead to invalid FHIR output.
 
@@ -433,7 +435,7 @@ To refer to nested elements, the path SHALL list the properties in order, separa
 
 Elements can offer a choice of reference types. In the FHIR specification, these choices are presented in the style Reference(Procedure \| Observation). To address a specific resource or profile among the choices, the target Resource or Profile (represented by a name, id, or url) SHALL be enclosed in square brackets and appended to the end of the path after the reference element (and slice name, if applicable).
 
-> **Note:** It is not permissible to cross reference boundaries in paths. This means that when a path gets to a Reference, that path cannot be extended further. For example, if Procedure has a subject element that has datatype Reference(Patient), and Patient has a gender, then `subject` is a valid path, but `subject.gender` is not, because it crosses into the Patient resource.
+> **Note:** It is not permissible to cross reference boundaries in paths. This means that when a path gets to a Reference, that path cannot be extended further. For example, if Procedure has a `subject` element that has datatype Reference(Patient), and Patient has a `gender`, then `subject` is a valid path, but `subject.gender` is not, because it crosses into the Patient resource.
 
 **Examples:**
 
@@ -443,7 +445,7 @@ Elements can offer a choice of reference types. In the FHIR specification, these
   performer[Practitioner]
   ```
 
-* Path to the Reference(US Core Organization) option of the performer element in [US Core DiagnosticReport Lab](https://hl7.org/fhir/us/core/StructureDefinition-us-core-diagnosticreport-lab.html), using the canonical URL:
+* Path to the Reference(US Core Organization) option of the `performer` element in [US Core DiagnosticReport Lab](https://hl7.org/fhir/us/core/StructureDefinition-us-core-diagnosticreport-lab.html), using the canonical URL:
 
   ```
   performer[http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization]
@@ -457,9 +459,9 @@ Elements can offer a choice of reference types. In the FHIR specification, these
 
 #### Data Type Choice [x] Paths
 
-FHIR represents an element with a choice of datatypes using the style foo[x]. For example, `Condition.onset[x]` can be a dateTime, Age, Period, Range or string. In FSH, [as in FHIR](https://hl7.org/fhir/R5/formats.html#choice), to refer to one of these datatypes, the `[x]` SHALL be replaced by the datatype name, capitalizing the first letter. For `Condition.onset[x]`, the individual choices are onsetDateTime, onsetAge, onsetPeriod, onsetRange, and onsetString.
+FHIR represents an element with a choice of datatypes using the style `foo[x]`. For example, `Condition.onset[x]` can be a dateTime, Age, Period, Range or string. In FSH, [as in FHIR](https://hl7.org/fhir/R5/formats.html#choice), to refer to one of these datatypes, the `[x]` SHALL be replaced by the datatype name, capitalizing the first letter. For `Condition.onset[x]`, the individual choices are `onsetDateTime`, `onsetAge`, `onsetPeriod`, `onsetRange`, and `onsetString`.
 
-> **Note:** foo[x] choices are NOT represented as foo[dateTime], foo[Period], etc.
+> **Note:** `foo[x]` choices are NOT represented as `foo[dateTime]`, `foo[Period]`, etc.
 
 **Examples:**
 
@@ -495,7 +497,7 @@ Numerical indices apply only to arrays that can be populated with concrete value
   name[0]
   ```
 
-* Path to a patient's second given name in the first name field within an instance of Patient:
+* Path to a patient's second `given` name in the first `name` field within an instance of Patient:
 
   ```
   name[0].given[1]
@@ -641,7 +643,7 @@ For locally-defined extensions, using the slice name is the simplest choice. For
   extension[birthsex].valueCode
   ```
 
-* Path to an extension on the telecom element of Patient, assuming the extension has been given the local slice name directMailAddress:
+* Path to an extension on the `telecom` element of Patient, assuming the extension has been given the local slice name directMailAddress:
 
   ```
   telecom.extension[directMailAddress]
@@ -653,7 +655,7 @@ For locally-defined extensions, using the slice name is the simplest choice. For
   telecom.extension[http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct]
   ```
 
-* Path to the Coding datatype of the value[x] in the nested extension ombCategory under the ethnicity extension in US Core, using the slice names of the extensions:
+* Path to the Coding datatype of the `value[x]` in the nested extension ombCategory under the ethnicity extension in US Core, using the slice names of the extensions:
 
   ```
   extension[ethnicity].extension[ombCategory].valueCoding
@@ -674,7 +676,7 @@ In order to address this gap, FSH authors MAY use the caret (`^`) symbol to acce
 * `snapshot.element` and `differential.element` in Profile, Extension, Logical, and Resource items
 * `compose.include` and `compose.exclude` in ValueSet items
 
-Examples of elements that require the caret syntax include `StructureDefinition.experimental`, `StructureDefinition.abstract` and `ValueSet.purpose`. The caret syntax also provides a simple way to set metadata attributes in the ElementDefinitions that comprise the snapshot and differential tables (e.g., short, meaningWhenMissing, and various [slicing discriminator properties](#step-1-specify-the-slicing-logic)).
+Examples of elements that require the caret syntax include `StructureDefinition.experimental`, `StructureDefinition.abstract` and `ValueSet.purpose`. The caret syntax also provides a simple way to set metadata attributes in the ElementDefinitions that comprise the snapshot and differential tables (e.g., `short`, `meaningWhenMissing`, and various [slicing discriminator properties](#step-1-specify-the-slicing-logic)).
 
 For a path to an element of a StructureDefinition, excluding the differential and snapshot, use the following syntax inside a Profile, Extension, Logical, or Resource:
 
@@ -786,7 +788,7 @@ The following keywords (case-sensitive) are defined:
 
 <span class="tuSpan"><sup>*</sup> Defining instances of logical models in FSH is {%include tu.html%}.</span>
 
-In the above, `name` refers to a valid [item name](#item-names) and `id` to an [item identifier](#item-identifiers).
+In the above, "name" refers to a valid [item name](#item-names) and "id" to an [item identifier](#item-identifiers).
 
 Depending on the type of item being defined, keywords may be REQUIRED, suggested (SHOULD be used), OPTIONAL, or prohibited (MUST NOT be used). The following table shows the relationship between declarations and keywords:
 
@@ -891,7 +893,7 @@ Rule types that apply to CodeSystems are: [Assignment](#assignment-rules), [Inse
 * There MUST NOT be a code system before the hash sign `#`. The code system name is given by the `CodeSystem` declaration.
 * The definition of the term, provided as the second string following the code, is RECOMMENDED but not REQUIRED.
 * Do not use the word `include` in a code system rule. The rule is creating a brand new code, not including an existing code defined elsewhere.
-* Metadata attributes for individual concepts, such as designation, MAY be defined using [caret paths](#caret-paths).
+* Metadata attributes for individual concepts, such as `designation`, MAY be defined using [caret paths](#caret-paths).
 * [Assignment rules](#assignment-rules) SHALL apply only to caret paths in CodeSystems.
 
 
@@ -991,9 +993,9 @@ For a path to a code within a code system, use this syntax:
 
 To define an extension, the declaration `Extension` is REQUIRED, the keywords `Id`, `Title`, and `Description` are RECOMMENDED, and `Parent` is OPTIONAL. Extensions MAY also inherit from other extensions, but if the `Parent` keyword is omitted, the parent SHALL be assumed to be FHIR's [Extension element](https://hl7.org/fhir/R5/extensibility.html#extension). Extension metadata that does not have a dedicated keyword MAY be specified using assignment rules with [caret paths](#caret-paths) (e.g., `^url`, `^status`, `^purpose`).
 
-An extension MAY have either a value (i.e. a value[x] element) or sub-extensions, but MUST NOT have both. To create a simple extension, the value[x] element SHOULD be constrained. To create a complex extension, the extension array of the extension MUST be sliced (see [Contains Rules for Extensions](#contains-rules-for-extensions)).
+An extension MAY have either a value (i.e. a `value[x]` element) or sub-extensions, but MUST NOT have both. To create a simple extension, the `value[x]` element SHOULD be constrained. To create a complex extension, the `extension` array of the extension MUST be sliced (see [Contains Rules for Extensions](#contains-rules-for-extensions)).
 
-Since simple and complex extensions are mutually-exclusive, FSH implementations SHOULD set the value[x] cardinality to 0..0 if sub-extensions are specified, set extension cardinality to 0..0 if constraints are applied to value[x], and signal an error if value[x] and extensions are simultaneously specified.
+Since simple and complex extensions are mutually-exclusive, FSH implementations SHOULD set the `value[x]` cardinality to 0..0 if sub-extensions are specified, set `extension` cardinality to 0..0 if constraints are applied to `value[x]`, and signal an error if `value[x]` and sub-extensions are simultaneously specified.
 
 To indicate that an extension is a [modifier extension](https://hl7.org/fhir/R5/extensibility.html#modifierExtension), authors MUST set the [isModifier](https://hl7.org/fhir/R5/elementdefinition-definitions.html#ElementDefinition.isModifier) flag to `true` on the extension's root element. In addition, the root element's [isModifierReason](https://hl7.org/fhir/R5/elementdefinition-definitions.html#ElementDefinition.isModifierReason) MUST also be provided. This is in accordance with FHIR's [modifier extension requirements](https://hl7.org/fhir/R5/extensibility.html#modifierExtension) and [eld-18](https://hl7.org/fhir/R5/elementdefinition-definitions.html#ElementDefinition.isModifier) invariant. FSH authors can achieve this via rules like the following:
 
@@ -1199,7 +1201,7 @@ Rule types that apply to Instances are: [Assignment](#assignment-rules), [Insert
 
 **Examples:**
 
-* Define an example instance of US Core Patient, with name, birthDate, race, and ethnicity:
+* Define an example instance of US Core Patient, with name, date of birth, race, and ethnicity:
 
   ```
   Instance:  EveAnyperson
@@ -1314,7 +1316,7 @@ Invariants are defined using the REQUIRED declaration `Invariant`, RECOMMENDED k
 
 <span class="caption" id="t8">Table 8. Keywords used to define Invariants</span>
 
-| Keyword | Usage | Corresponding element in <br/> `ElementDefinition.constraint` | Data Type | Required |
+| Keyword | Usage | Corresponding element in <br/> ElementDefinition.constraint | Data Type | Required |
 |-------------|-----------------------------------|------------|-----------------|----------------|
 | Invariant   | Identifier for the invariant      | key        | id              | yes            |
 | Description | Human description of constraint   | human      | string          | no<sup>1</sup> |
@@ -1359,11 +1361,11 @@ Rule types that apply to defining Invariants are: [Assignment](#assignment-rules
 
 Logical models allow authors to define new structures representing arbitrary content. While profiles can only add new properties as formal extensions, logical models add properties as standard elements with standard paths. Logical models have many uses, [as described in the FHIR specification](https://hl7.org/fhir/R5/structuredefinition.html#logical), but are often used to convey domain-specific concepts in a user-friendly manner. Authors often use logical models as a basis for defining formal profiles in FHIR.
 
-Logical models are defined using the REQUIRED declaration `Logical`, with RECOMMENDED keywords `Id`, `Title`, and `Description`, and OPTIONAL keyword `Parent`. If no `Parent` is specified, the empty [Base](https://hl7.org/fhir/R5/types.html#Base) type SHALL be assumed as the default parent. Note that the Base type does not exist in FHIR R4, but both SUSHI and the FHIR IG Publisher have implemented special case logic to support Base in FHIR R4. Authors who wish to have top-level id and extension elements MAY use [Element](https://hl7.org/fhir/R5/types.html#Element) as the logical model's parent instead (when appropriate, based on the definition of Element). Alternately, authors MAY specify another logical model, a resource, or a complex datatype as a logical model's parent. Logical model metadata that does not have a dedicated keyword MAY be specified using assignment rules with [caret paths](#caret-paths) (e.g., `^url`, `^status`, `^purpose`).
+Logical models are defined using the REQUIRED declaration `Logical`, with RECOMMENDED keywords `Id`, `Title`, and `Description`, and OPTIONAL keyword `Parent`. If no `Parent` is specified, the empty [Base](https://hl7.org/fhir/R5/types.html#Base) type SHALL be assumed as the default parent. Note that the Base type does not exist in FHIR R4, but both SUSHI and the FHIR IG Publisher have implemented special case logic to support Base in FHIR R4. Authors who wish to have top-level `id` and `extension` elements MAY use [Element](https://hl7.org/fhir/R5/types.html#Element) as the logical model's parent instead (when appropriate, based on the definition of Element). Alternately, authors MAY specify another logical model, a resource, or a complex datatype as a logical model's parent. Logical model metadata that does not have a dedicated keyword MAY be specified using assignment rules with [caret paths](#caret-paths) (e.g., `^url`, `^status`, `^purpose`).
 
 Rules defining the logical model follow immediately after the keyword section. Rule types that apply to Logicals are: [Add Element](#add-element-rules), [Assignment](#assignment-rules), [Binding](#binding-rules), [Cardinality](#cardinality-rules), [Flag](#flag-rules), [Insert](#insert-rules), [Obeys](#obeys-rules), [Path](#path-rules), and [Type](#type-rules). Flag rules SHALL NOT include MS flags.
 
-In addition, authors SHOULD consult FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements listed as prohibited in that table. For example, the table indicates that assigning maxLength and mustSupport is prohibited.
+In addition, authors SHOULD consult FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements listed as prohibited in that table. For example, the table indicates that assigning `maxLength` and `mustSupport` is prohibited.
 
 > **Note:** Prior versions of FHIR Shorthand forbid logical model definitions from constraining inherited elements or using assignment rules to fix element values. These capabilities MAY now be used as {%include tu.html%} features of FSH.
 
@@ -1452,7 +1454,7 @@ The mappings themselves are declared in rules with the following syntaxes:
 * &lt;element&gt; -> "{map string}" <span class="optional">"{comment string}" #{mime-type code}</span>
 </code></pre>
 
-A rule starting with the characters `->` SHALL map the profile as a whole to a target. A rule starting with an element followed by the characters `->` SHALL map a specific element within the source to a target. The `map`, `comment`, and `mime-type` are as defined in FHIR and correspond to elements in [StructureDefinition.mapping](https://hl7.org/fhir/structuredefinition.html) and [ElementDefinition.mapping](https://hl7.org/fhir/R5/elementdefinition.html) (map corresponds to `mapping.map`, mime-type to `mapping.language`, and comment to `mapping.comment`). The mime type code MUST come from FHIR's [MimeType value set](https://hl7.org/fhir/R5/valueset-mimetypes.html). For further information, refer to the FHIR definitions of these elements.
+A rule starting with the characters `->` SHALL map the profile as a whole to a target. A rule starting with an element followed by the characters `->` SHALL map a specific element within the source to a target. The `map`, `comment`, and `mime-type` are as defined in FHIR and correspond to elements in [StructureDefinition.mapping](https://hl7.org/fhir/structuredefinition.html) and [ElementDefinition.mapping](https://hl7.org/fhir/R5/elementdefinition.html) (`map` corresponds to `mapping.map`, `mime-type` to `mapping.language`, and `comment` to `mapping.comment`). The mime type code MUST come from FHIR's [MimeType value set](https://hl7.org/fhir/R5/valueset-mimetypes.html). For further information, refer to the FHIR definitions of these elements.
 
 >**Note:** Unlike setting the `mapping.map` directly in the StructureDefinition, mapping rules within a Mapping item MUST NOT include the name of the resource in the path on the left hand side.
 
@@ -1525,7 +1527,7 @@ Rules defining the resource follow immediately after the keyword section. Rules 
 * Flag rules SHALL NOT include MS flags.
 * Assignment rules SHALL be used only with caret paths.
 
-The latter restrictions stem from FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements that are prohibited in that table. For example, the table indicates that setting maxLength or mustSupport is prohibited.
+The latter restrictions stem from FHIR's [interpretation of ElementDefinition for type definitions](https://hl7.org/fhir/R5/elementdefinition.html#interpretation). Assignments MUST NOT set elements that are prohibited in that table. For example, the table indicates that setting `maxLength` or `mustSupport` is prohibited.
 
 **Example:**
 
@@ -2080,7 +2082,7 @@ When indented rules are combined with [soft indexing](#array-paths-using-soft-in
   * rest.resource[1].interaction[1].code = #update
   ```
 
-* An error, attempting to use a rule without a path as context for an indented rule, since "obeys" does not imply a path:
+* An error, attempting to use a rule without a path as context for an indented rule, since `obeys` does not imply a path:
   
   ```
   * obeys inv-1
@@ -2120,7 +2122,7 @@ Note the following:
 * Flags and longer definition are OPTIONAL.
 * The longer definition MAY also be a multi-line (triple quoted) string.
 * If a longer definition is not specified, FSH implementers SHALL set the element's definition to the same text as the specified short description.
-* When multiple types are specified, the element path MUST end with \[x] unless all types are References, all types are Canonicals, or {%include tu-span.html%} all types are CodeableReferences</span>.
+* When multiple types are specified, the element path MUST end with `[x]` unless all types are References, all types are Canonicals, or {%include tu-span.html%} all types are CodeableReferences</span>.
 
 **Examples:**
 
@@ -2197,7 +2199,7 @@ Assignment rules have two very different interpretations, depending on context:
 * In instances {%include tu-span.html%} and invariants</span>, assignment rules set the **value** of the target element. Note that whenever an element is accessed via a [caret path](#caret-paths), it is actually accessing the definitional instance (for example, the StructureDefinition of the profile). Therefore, assignments involving caret paths also set the **value** of the target element.
 * Assignment rules in profiles and extensions establish **constraints** on instances conforming to the profile or extension. The requirement is expressed as a pattern of values that MUST be present in the instance. In this context, an assignment rule does not set the value of the element, but instead, establishes a **constraint** on that value.
 
-This is best illustrated by example. Consider the following assignment (assuming code is a CodeableConcept):
+This is best illustrated by example. Consider the following assignment (assuming `code` is a CodeableConcept):
 
 ```
 * code = https://loinc.org#69548-6
@@ -2205,7 +2207,7 @@ This is best illustrated by example. Consider the following assignment (assuming
 
 If this statement appears in an instance of an Observation, then the values of `code.coding[0].system` and `code.coding[0].code` will be set to https://loinc.org and 69548-6, respectively, in that Observation.
 
-If the identical statement appears in a profile on Observation, it signals that the StructureDefinition is configured such that the code element of a conformant instance MUST have a Coding with the system http://loinc.org and the code 69548-6. (In fact, the StructureDefinition does not even *have* a code element to populate.)
+If the identical statement appears in a profile on Observation, it signals that the StructureDefinition is configured such that the `code` element of a conformant instance MUST have a Coding with the system http://loinc.org and the code 69548-6. (In fact, the StructureDefinition does not even *have* its own `code` element to populate.)
 
 > **Note**: In the profiling context, typically only the system and code are important conformance criteria for a Coding or CodeableConcept property. If a display text is included, it will be part of the conformance criteria.
 
@@ -2267,7 +2269,7 @@ When assigning values to an instance, the `(exactly)` modifier has no meaning an
 
 ##### Assignments with the Coding Data Type
 
-A FHIR Coding has five attributes (system, version, code, display, and userSelected). The first four of these MAY be set with a single assignment statement. The syntax is:
+A FHIR Coding has five attributes (`system`, `version`, `code`, `display`, and `userSelected`). The first four of these MAY be set with a single assignment statement. The syntax is:
 
 <pre><code>&lt;Coding&gt; = <span class="optional">{CodeSystem}|{version string}</span>#{code} <span class="optional">"{display string}"</span></code></pre>
 
@@ -2295,7 +2297,7 @@ Whenever this type of rule is applied, whatever is on the right side SHALL **ent
   * myCoding.version = "201801103"
   ```
 
-* Set the userSelected property of a Coding (one of the lesser-used attributes of Codings):
+* Set the `userSelected` property of a Coding (one of the lesser-used attributes of Codings):
 
   ```
   * myCoding.userSelected = true
@@ -2313,24 +2315,24 @@ Whenever this type of rule is applied, whatever is on the right side SHALL **ent
   * myCoding = $SCT#363346000 "Malignant neoplastic disease (disorder)"
   * myCoding = $ICD#C80.1
   ```
-  Because the second assignment clears the previous value of myCoding, the result is:
+  Because the second assignment clears the previous value of `myCoding`, the result is:
 
-  * myCoding.system is http://hl7.org/fhir/sid/icd-10-cm (assuming the $ICD alias maps to this URL)
-  * myCoding.code is "C80.1"
-  * myCoding.display **has no value**
-  * myCoding.version **has no value**
+  * `myCoding.system` is http://hl7.org/fhir/sid/icd-10-cm (assuming the $ICD alias maps to this URL)
+  * `myCoding.code` is "C80.1"
+  * `myCoding.display` **has no value**
+  * `myCoding.version` **has no value**
 
-* Example of how **incorrectly** ordered rules can lead to loss of a previously-assigned value, because myCoding is cleared as part of the second assignment:
+* Example of how **incorrectly** ordered rules can lead to loss of a previously-assigned value, because `myCoding` is cleared as part of the second assignment:
 
   ```
   * myCoding.userSelected = true
   * myCoding = $SCT#363346000 "Malignant neoplastic disease (disorder)"
   ```
   The result is:
-  * system is http://snomed.info/sct
-  * code is "363346000"
-  * display is "Malignant neoplastic disease (disorder)"
-  * userSelected **has no value**
+  * `system` is http://snomed.info/sct
+  * `code` is "363346000"
+  * `display` is "Malignant neoplastic disease (disorder)"
+  * `userSelected` **has no value**
 
 * The correct way to approach the previous example is to reverse the order of the assignments:
 
@@ -2353,7 +2355,7 @@ To set the first Coding in a CodeableConcept, FSH offers the following shortcut:
 
 Whenever the shortcut rule is applied, the value on the right side SHALL **entirely replace** any previous value of the CodeableConcept on the left side. Any previous value(s) in the CodeableConcept are cleared.
 
-Assignment rules MAY be used to set any part of a CodeableConcept. For example, to set the top-level text of a CodeableConcept, the FSH expression is:
+Assignment rules MAY be used to set any part of a CodeableConcept. For example, to set the top-level `text` attribute of a CodeableConcept, the FSH expression is:
 
 ```
 * <CodeableConcept>.text = "{string}"
@@ -2361,19 +2363,19 @@ Assignment rules MAY be used to set any part of a CodeableConcept. For example, 
 
 **Examples:**
 
-* Set the first Coding myCodeableConcept:
+* Set the first Coding in `myCodeableConcept`:
 
   ```
   * myCodeableConcept = $SCT#363346000 "Malignant neoplastic disease (disorder)"
   ```
     
-* An equivalent representation, using explicit array index on the coding array:
+* An equivalent representation, using an explicit array index on the `coding` array:
 
   ```
   * myCodeableConcept.coding[0] = $SCT#363346000 "Malignant neoplastic disease (disorder)"
   ```
     
-* Another equivalent representation, using the shorthand that allows dropping the [0] index:
+* Another equivalent representation, using the shorthand that allows dropping the `[0]` index:
 
   ```
   * myCodeableConcept.coding = $SCT#363346000 "Malignant neoplastic disease (disorder)"
@@ -2385,13 +2387,13 @@ Assignment rules MAY be used to set any part of a CodeableConcept. For example, 
   * myCodeableConcept.coding[1] = $ICD#C80.1 "Malignant (primary) neoplasm, unspecified"
   ```
     
-* Set the top-level text:
+* Set the top-level `text` attribute:
 
   ```
   * myCodeableConcept.text = "Diagnosis of malignant neoplasm left breast."
   ```
 
-* Example of **incorrect** ordering rules that leads to loss of a previously-assigned value, because the last assignment clears the existing value of myCodeableConcept before apply new values:
+* Example of **incorrect** ordering rules that lead to loss of a previously-assigned value, because the last assignment clears the existing value of `myCodeableConcept` before it applies new values:
 
   ```
   * myCodeableConcept.coding[0].userSelected = true
@@ -2400,13 +2402,13 @@ Assignment rules MAY be used to set any part of a CodeableConcept. For example, 
   ```
   The result is:
   
-  * coding[0].system is http://snomed.info/sct
-  * coding[0].code is "363346000"
-  * display is "Malignant neoplastic disease (disorder)"
-  * coding[0].userSelected **has no value**
-  * text **has no value**
+  * `coding[0].system` is http://snomed.info/sct
+  * `coding[0].code` is "363346000"
+  * `display` is "Malignant neoplastic disease (disorder)"
+  * `coding[0].userSelected` **has no value**
+  * `text` **has no value**
 
-* The correct way to approach the previous example is to set the values of userSelected and text **after** setting the coding, since those assignments only change the specific subelements on the left side of those assignments:
+* The correct way to approach the previous example is to set the values of `userSelected` and `text` **after** setting the `coding`, since those assignments only change the specific subelements on the left side of those assignments:
 
   ```
   * myCodeableConcept = $SCT#363346000 "Malignant neoplastic disease (disorder)"
@@ -2440,13 +2442,13 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
 
 **Examples:**
 
-* Set the valueQuantity of an Observation to 55 millimeters using UCUM units:
+* Set the `valueQuantity` of an Observation to 55 millimeters using UCUM units:
 
   ```
   * valueQuantity = 55.0 'mm'
   ```
 
-* Set the valueQuantity of an Observation to 55 millimeters using UCUM units and a display string:
+* Set the `valueQuantity` of an Observation to 55 millimeters using UCUM units and a display string:
 
   ```
   * valueQuantity = 55.0 'mm' "millimeter"
@@ -2482,12 +2484,12 @@ For non-UCUM units, the units of measure MAY be set independently by assigning a
   * valueQuantity.unit = "millimeter"
   * valueQuantity = 55.0 'mm'
   ```
-  Note that the second rule **clears** valueQuantity in its entirety before applying the specified values, so the result is:
+  Note that the second rule **clears** `valueQuantity` in its entirety before applying the specified values, so the result is:
 
-  * value is 55.0
-  * system is http://unitsofmeasure.org
-  * code is "mm"
-  * unit **has no value**
+  * `value` is 55.0
+  * `system` is http://unitsofmeasure.org
+  * `code` is "mm"
+  * `unit` **has no value**
 
 * The correct way to approach the previous example, so unit has the desired value, is simply to reverse the order of rules:
 
@@ -2550,9 +2552,9 @@ As [advised in FHIR](https://hl7.org/fhir/R5/references.html#canonical), the URL
 
 {%include tu-div.html%}
 
-The [CodeableReference](https://hl7.org/fhir/R5/references.html#codeablereference) datatype was introduced as part of FHIR R5 release sequence. This type allows for a concept, a reference, or both. FSH supports applying bindings directly to CodeableReferences and directly constraining types on CodeableReferences. When applying a type rule (e.g., `code only CodeableReference(Medication)`), the element's reference property SHALL be constrained to the given type, but its concept property SHALL remain available for use (unless otherwise constrained by another rule).
+The [CodeableReference](https://hl7.org/fhir/R5/references.html#codeablereference) datatype was introduced as part of FHIR R5 release sequence. This type allows for a concept, a reference, or both. FSH supports applying bindings directly to CodeableReferences and directly constraining types on CodeableReferences. When applying a type rule (e.g., `code only CodeableReference(Medication)`), the element's `reference` property SHALL be constrained to the given type, but its `concept` property SHALL remain available for use (unless otherwise constrained by another rule).
 
-To assign values to a CodeableReference, authors MAY assign a FSH Coding or reference directly to the CodeableReference element. Assigning a Coding to a CodeableReference element SHALL assign the Coding to the element's concept property. Assigning a reference to a CodeableReference element SHALL assign the reference to the element's reference property. Assigning a Coding SHALL NOT affect the CodeableReference's reference property. Similarly, assigning a reference SHALL NOT affect the CodeableReference's concept property. If preferred, authors MAY assign a CodeableConcept's concept and reference properties directly.
+To assign values to a CodeableReference, authors MAY assign a FSH Coding or reference directly to the CodeableReference element. Assigning a Coding to a CodeableReference element SHALL assign the Coding to the element's `concept` property. Assigning a reference to a CodeableReference element SHALL assign the reference to the element's `reference` property. Assigning a Coding SHALL NOT affect the CodeableReference's `reference` property. Similarly, assigning a reference SHALL NOT affect the CodeableReference's `concept` property. If preferred, authors MAY assign a CodeableConcept's `concept` and `reference` properties directly.
 
 **Examples:**
 
@@ -2569,7 +2571,7 @@ To assign values to a CodeableReference, authors MAY assign a FSH Coding or refe
   * code only CodeableReference(LatexSubstanceDefinition)
   ```
 
-* Assign the concept and reference properties of a CodeableReference by assigning values directly to the CodeableReference element:
+* Assign the `concept` and `reference` properties of a CodeableReference by assigning values directly to the CodeableReference element:
 
   ```
   Instance:   LatexSubstanceExample
@@ -2580,7 +2582,7 @@ To assign values to a CodeableReference, authors MAY assign a FSH Coding or refe
   * code = Reference(NaturalLatexSubstanceDefinitionExample)
   ```
 
-* Assign the concept and reference properties of a CodeableReference by assigning values directly to each property. This has the same result as the example above:
+* Assign the `concept` and `reference` properties of a CodeableReference by assigning values directly to each property. This has the same result as the example above:
 
   ```
   Instance:   LatexSubstanceExample
@@ -2599,7 +2601,7 @@ When the left side of an assignment rule contains a caret path, the value SHALL 
 
 **Examples**
 
-* Assign the experimental flag in a profile's StructureDefinition to `true`:
+* Assign the `experimental` flag in a profile's StructureDefinition to `true`:
 
   ```
   * ^experimental = true
@@ -2696,9 +2698,9 @@ To change the cardinality, the syntax is:
 * <element> ..{max}   // leave min as-is
 ```
 
-As in FHIR, min MUST be a non-negative integer and max MUST be a non-negative integer or *, representing unbounded. Authors MAY include both the min and max, even if one of them remains the same as in the original cardinality. In this case, FSH implementations SHOULD only generate constraints for the changed values.
+As in FHIR, `min` MUST be a non-negative integer and `max` MUST be a non-negative integer or *, representing unbounded. Authors MAY include both the `min` and `max`, even if one of them remains the same as in the original cardinality. In this case, FSH implementations SHOULD only generate constraints for the changed values.
 
-Cardinalities MUST follow [rules of FHIR profiling](https://hl7.org/fhir/R5/conformance-rules.html#cardinality), namely that the min and max cardinalities comply within the constraints of the parent.
+Cardinalities MUST follow [rules of FHIR profiling](https://hl7.org/fhir/R5/conformance-rules.html#cardinality), namely that the `min` and `max` cardinalities comply within the constraints of the parent.
 
 For convenience and compactness, cardinality rules MAY be combined with [flag rules](#flag-rules) via the following syntax:
 
@@ -2710,13 +2712,13 @@ For convenience and compactness, cardinality rules MAY be combined with [flag ru
 
 **Examples:**
 
-* Set the cardinality of the subject element to 1..1 (required, non-repeating):
+* Set the cardinality of the `subject` element to 1..1 (required, non-repeating):
 
   ```
   * subject 1..1
   ```
 
-* Set the cardinality of the subject element to 1..1 and declare it Must Support:
+* Set the cardinality of the `subject` element to 1..1 and declare it Must Support:
 
   ```
   * subject 1..1 MS
@@ -2728,13 +2730,13 @@ For convenience and compactness, cardinality rules MAY be combined with [flag ru
   * component.referenceRange 0..0
   ```
 
-* Require at least one category without changing its upper bound:
+* Require at least one `category` without changing its upper bound:
 
   ```
   * category 1..
   ```
 
-* Allow at most one category without changing its lower bound:
+* Allow at most one `category` without changing its lower bound:
 
   ```
   * category ..1
@@ -2770,7 +2772,7 @@ The syntaxes to define inline extension(s) are:
 
 In these expressions, the names (`name`, `name1`, `name2`, etc.) are new local names created by the rule author. They are used to refer to that extension in later rules. By convention, the local names SHOULD be [lower camelCase](https://wiki.c2.com/?CamelCase). Implementers SHALL export these names as slice names in the generated StructureDefinition.
 
-> **Note:** Contains rules MAY also be applied to modifierExtension arrays by replacing `extension` with `modifierExtension` in the above syntaxes.
+> **Note:** Contains rules MAY also be applied to `modifierExtension` arrays by replacing `extension` with `modifierExtension` in the above syntaxes.
 
 **Examples:**
 
@@ -2803,7 +2805,7 @@ In these expressions, the names (`name`, `name1`, `name2`, etc.) are new local n
   * modifierExtension contains $DoNotPerform named doNotPerform 0..1 MS
   ```
 
-* Add a standalone extension Laterality, defined in the same FSH project, to a bodySite attribute (second level extension):
+* Add a standalone extension Laterality, defined in the same FSH project, to a `bodySite` attribute (second level extension):
 
   ```
   * bodySite.extension contains Laterality named laterality 0..1
@@ -2846,7 +2848,7 @@ The slicing logic parameters MUST be specified using [caret paths](#caret-paths)
 
 **Example:**
 
-* Provide slicing logic for slices on `Observation.component` that are to be distinguished by their code:
+* Provide slicing logic for slices on `Observation.component` that are to be distinguished by their sub-element `code`:
 
   ```
   * component ^slicing.discriminator.type = #pattern
@@ -2873,7 +2875,7 @@ In this pattern, `<array>` is a path to the element that is to be sliced and MUS
 Each slice matches or constrains the datatype of the array it slices. In particular:
 
 * If the sliced element is an array of a FHIR datatype, each slice will be the same datatype or a profile of it. For example, if `Observation.identifier` is sliced, each slice will have type Identifier or be constrained to a profile of the Identifier datatype.
-* If the sliced element is an array of a backbone element, each slice "inherits" the sub-elements of the backbone. For example, the slices of `Observation.component` possess all the elements of `Observation.component` (code, value[x], dataAbsentReason, etc.). Constraints MAY be applied to the slices.
+* If the sliced element is an array of a backbone element, each slice "inherits" the sub-elements of the backbone. For example, the slices of `Observation.component` possess all the elements of `Observation.component` (`code`, `value[x]`, `dataAbsentReason`, etc.). Constraints MAY be applied to the slices.
 * If the sliced element is an array of a Reference, then each slice MUST be a reference to one or more of the allowed Reference types. For example, if the element to be sliced is Reference(Observation or Condition), then each slice MUST either be Reference(Observation or Condition), Reference(Observation), Reference(Condition), or a profiled version of those resources.
 
 FSH implementations MUST add new slices to the StructureDefinition in the order in which they appear within the contains rule. When a FSH definition has multiple contains rules on the same path, these rules MUST be processed in the order in which they appear.
@@ -3016,7 +3018,7 @@ The following syntaxes MAY be used to assign flags:
 
 **Examples:**
 
-* Declare communication to be a Must Support and Summary element:
+* Declare `communication` to be a Must Support and Summary element:
 
   ```
   * communication MS SU
@@ -3391,14 +3393,14 @@ Path rules MAY also be used to indicate the order for slices to appear in an Ins
 {%include tu-div.html%}
 * Indicate the order for slices to appear in an Instance:
 
-  Given a profile that has a required "lab" slice on category, such as:
+  Given a profile that has a required "lab" slice on `category`, such as:
 
   ```
   * category contains lab 1..1
   * category[lab] = $OBSCAT#laboratory
   ```
 
-  an Instance of that profile can specify that the "lab" slice MUST come before other values on category by including the following path rule before other rules:
+  an Instance of that profile can specify that the "lab" slice MUST come before other values on `category` by including the following path rule before other rules:
 
   ```
   * category[lab]
@@ -3462,7 +3464,7 @@ FSH rules MAY also be used to restrict the target types of CodeableReference ele
 ```
 </div>
 
-Certain elements in FHIR offer a choice of datatypes using the [x] syntax. Choices also frequently appear in references. For example, `Condition.recorder` has the choice Reference(Practitioner or PractitionerRole or Patient or RelatedPerson). In both cases, choices MAY be restricted in two ways: reducing the number or choices, and/or substituting a more restrictive datatype or profile for one of the choices appearing in the parent profile or resource. In some cases, the right-hand side of a type rule MAY have a combination of datatype, Reference, Canonical, and {%include tu-span.html%}CodeableReference<span> targets.
+Certain elements in FHIR offer a choice of datatypes using the `[x]` syntax. Choices also frequently appear in references. For example, `Condition.recorder` has the choice Reference(Practitioner or PractitionerRole or Patient or RelatedPerson). In both cases, choices MAY be restricted in two ways: reducing the number or choices, and/or substituting a more restrictive datatype or profile for one of the choices appearing in the parent profile or resource. In some cases, the right-hand side of a type rule MAY have a combination of datatype, Reference, Canonical, and {%include tu-span.html%}CodeableReference<span> targets.
 
 Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5/profiling.html), the datatype(s) in a type rule MUST always be more restrictive than the original datatype. For example, if the parent datatype is Quantity, it MAY be replaced by SimpleQuantity, since SimpleQuantity is a profile on Quantity (hence more restrictive than Quantity itself), but MUST NOT be replaced with Ratio, because Ratio is not a type of Quantity. Similarly, `Condition.subject`, defined as Reference(Patient or Group), MAY be constrained to Reference(Patient), Reference(Group), or Reference(us-core-patient), but MUST NOT be restricted to Reference(RelatedPerson), since that is neither a Patient nor a Group.
 
@@ -3474,19 +3476,19 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
   * valueQuantity only SimpleQuantity
   ```
 
-* `Condition.onset[x]` is a choice of dateTime, Age, Period, Range or string. To restrict onset[x] to dateTime:
+* `Condition.onset[x]` is a choice of dateTime, Age, Period, Range or string. To restrict `onset[x]` to dateTime:
 
   ```
   * onset[x] only dateTime
   ```
 
-* Restrict onset[x] to either Period or Range:
+* Restrict `onset[x]` to either Period or Range:
 
   ```
   * onset[x] only Period or Range
   ```
 
-* Restrict onset[x] to Age, AgeRange, or DateRange, assuming AgeRange and DateRange are profiles of FHIR's Range datatype (thus permissible restrictions on Range):
+* Restrict `onset[x]` to Age, AgeRange, or DateRange, assuming AgeRange and DateRange are profiles of FHIR's Range datatype (thus permissible restrictions on Range):
 
   ```
   * onset[x] only Age or AgeRange or DateRange
@@ -3494,7 +3496,7 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
 
 {%include tu-div.html%}
 
-* Restrict value[x] to the integer64 type (note: this datatype was introduced in FHIR R5):
+* Restrict `value[x]` to the integer64 type (note: this datatype was introduced in FHIR R5):
 
   ```
   * value[x] only integer64
@@ -3508,25 +3510,25 @@ Following [standard profiling rules established in FHIR](https://hl7.org/fhir/R5
   * performer only Reference(Practitioner)
   ```
 
-* Restrict performer to either a Practitioner or a PractitionerRole:
+* Restrict `performer` to either a Practitioner or a PractitionerRole:
 
   ```
   * performer only Reference(Practitioner or PractitionerRole)
   ```
 
-* Restrict performer to PrimaryCarePhysician or EmergencyRoomPhysician (assuming these are profiles on Practitioner):
+* Restrict `performer` to PrimaryCarePhysician or EmergencyRoomPhysician (assuming these are profiles on Practitioner):
 
   ```
   * performer only Reference(PrimaryCarePhysician or EmergencyRoomPhysician)
   ```
 
-* Restrict the Practitioner choice of performer to a PrimaryCarePhysician, without restricting other choices. Because the path specifically calls out the Practitioner choice, the result is that performer can reference a Practitioner resource that validates against the PrimaryCareProvider profile or any of the other choices (PractitionerRole, Organization, CareTeam, Patient, and RelatedPerson):
+* Restrict the Practitioner choice of `performer` to a PrimaryCarePhysician, without restricting other choices. Because the path specifically calls out the Practitioner choice, the result is that `performer` can reference a Practitioner resource that validates against the PrimaryCareProvider profile or any of the other choices (PractitionerRole, Organization, CareTeam, Patient, and RelatedPerson):
 
   ```
   * performer[Practitioner] only Reference(PrimaryCareProvider)
   ```
 
-* Assuming that LiteralReference is a profile on Reference, restrict the performer Reference datatype to this LiteralReference profile and its target types to Practitioner or PractitionerRole. Note that the first rule restricts the Reference datatype and the second rule restricts the types it MAY refer to:
+* Assuming that LiteralReference is a profile on Reference, restrict the `performer` Reference datatype to this LiteralReference profile and its target types to Practitioner or PractitionerRole. Note that the first rule restricts the Reference datatype and the second rule restricts the types it MAY refer to:
 
   ```
   * performer only LiteralReference


### PR DESCRIPTION
This PR addresses [FHIR-42345](https://jira.hl7.org/browse/FHIR-42345) by applying more consistent styling across the specification. After discussion with the team, including review of the FHIR and US Core specifications, we determined that the following things should use `code` styling:
* element paths, such as `Patient.name.given` and `name.given`
* resource attributes, such as `value[x]`
* symbols (when standing alone), such as `$` and `#`
* listed binding strengths, such as `required`, `extensible`, `preferred`, and `example`
* flags, such as `MU`
* slice names, such as `bpSystolic` and `bpDiastolic`
* Author-defined FSH entity names, such as `LateralityExtension`
* Aliases, such as `$LOINC`,
* FSH codes, such as `$LOINC#1234-5` and `#active`

Please review to ensure I've applied these consistently. Also consider if we should apply `code` styling to all of these, or if it is too much. Each type is applied in its own commit so we can more easily back out changes if needed.

To see the autobuild of this branch, go here: https://build.fhir.org/ig/HL7/fhir-shorthand/branches/fsh-3.0-resolutions-cmm-4/index.html

_NOTE: I did not apply these styles to the change log. I expect to do a full change log update in a separate commit._